### PR TITLE
Add login structure management and popup handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
-# aaa
+# Automated Sales Analysis
+
+This project automates login and navigation for the BGF Retail store site using Selenium.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Create a `.env` file with your credentials:
+   ```
+   LOGIN_ID=your_username
+   LOGIN_PW=your_password
+   ```
+3. Run the script:
+   ```bash
+   python main.py
+   ```
+
+The script checks for `structure/login_structure.json`. If it does not exist, it will be created automatically via `crawl/login_structure.py`.
+
+On Mondays the script navigates to **매출분석 > 중분류별 매출 구성비** using `navigate_sales_ratio.py` after closing any login pop‑ups.
+Data extracted by future features will be stored under the `sales_analysis` directory.

--- a/crawl/login_structure.py
+++ b/crawl/login_structure.py
@@ -1,0 +1,19 @@
+import os
+import json
+
+
+def create_login_structure():
+    """Create login structure file with selectors."""
+    os.makedirs('structure', exist_ok=True)
+    cfg = {
+        "url": "https://store.bgfretail.com/websrc/deploy/index.html",
+        "id_selector": "#input_id",
+        "password_selector": "#input_pw",
+        "submit_selector": "button[type=submit]"
+    }
+    with open(os.path.join('structure', 'login_structure.json'), 'w') as f:
+        json.dump(cfg, f, indent=2)
+
+
+if __name__ == "__main__":
+    create_login_structure()

--- a/main.py
+++ b/main.py
@@ -4,9 +4,18 @@ from datetime import datetime
 from dotenv import load_dotenv
 from selenium import webdriver
 from selenium.webdriver.common.by import By
-from selenium.webdriver.common.keys import Keys
 
 from navigate_sales_ratio import navigate_sales_ratio
+
+
+def load_login_structure():
+    """Load login structure file or create it using the crawler."""
+    path = os.path.join('structure', 'login_structure.json')
+    if not os.path.exists(path):
+        from crawl.login_structure import create_login_structure
+        create_login_structure()
+    with open(path) as f:
+        return json.load(f)
 
 
 POPUP_CLOSE_SELECTORS = [
@@ -40,6 +49,13 @@ def close_popups(driver, max_loops=2):
             break
 
 
+def extract_sales_data():
+    """Placeholder for future data extraction logic."""
+    os.makedirs('sales_analysis', exist_ok=True)
+    with open(os.path.join('sales_analysis', 'data.txt'), 'w') as f:
+        f.write('placeholder')
+
+
 def main():
     load_dotenv()
     login_id = os.getenv('LOGIN_ID')
@@ -47,25 +63,26 @@ def main():
     if not login_id or not login_pw:
         raise ValueError('LOGIN_ID or LOGIN_PW not set in environment')
 
-    with open('main_order_login.json') as f:
-        cfg = json.load(f)
+    cfg = load_login_structure()
 
     driver = webdriver.Chrome()
     driver.get(cfg['url'])
 
     id_field = driver.find_element(By.CSS_SELECTOR, cfg['id_selector'])
     id_field.send_keys(login_id)
-    id_field.send_keys(Keys.ENTER)
 
     pw_field = driver.find_element(By.CSS_SELECTOR, cfg['password_selector'])
     pw_field.send_keys(login_pw)
-    pw_field.send_keys(Keys.ENTER)
+
+    submit_btn = driver.find_element(By.CSS_SELECTOR, cfg['submit_selector'])
+    submit_btn.click()
 
     # Ensure all popups are closed before proceeding
     close_popups(driver)
 
     if datetime.now().weekday() == 0:
         navigate_sales_ratio(driver)
+        extract_sales_data()
 
     # Placeholder for data extraction logic after navigation
     # Data should be saved under sales_analysis

--- a/structure/login_structure.json
+++ b/structure/login_structure.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://store.bgfretail.com/websrc/deploy/index.html",
+  "id_selector": "#input_id",
+  "password_selector": "#input_pw",
+  "submit_selector": "button[type=submit]"
+}


### PR DESCRIPTION
## Summary
- create `structure/login_structure.json` and generator script
- update `main.py` to load or generate login structure
- ensure pop-ups close before Monday navigation
- add placeholder data extraction logic
- document setup and behavior in README

## Testing
- `python -m py_compile main.py navigate_sales_ratio.py crawl/login_structure.py`


------
https://chatgpt.com/codex/tasks/task_e_685b365404188320ace36806529608dc