### PR TITLE
Refresh login structure at runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,10 @@ This project automates login and navigation for the BGF Retail store site using 
    python main.py
    ```
 
-The script checks for `structure/login_structure.json`. If it does not exist, it will be created automatically via `crawl/login_structure.py`, which attempts to parse the login page and determine form selectors automatically. Generic selectors are used if the page cannot be fetched.
+`crawl/login_structure.py` refreshes `structure/login_structure.json` every time the
+script runs by parsing the login page. Generic selectors are used if the page
+cannot be fetched, ensuring the login process always starts with an up‑to‑date
+structure file.
 
 On Mondays the script navigates to **매출분석 > 중분류별 매출 구성비** using `navigate_sales_ratio.py` after closing any login pop‑ups.
 Data extracted by future features will be stored under the `sales_analysis` directory.

--- a/main.py
+++ b/main.py
@@ -9,11 +9,13 @@ from navigate_sales_ratio import navigate_sales_ratio
 
 
 def load_login_structure():
-    """Load login structure file or create it using the crawler."""
+    """Always recreate the login structure before loading it."""
+    from crawl.login_structure import create_login_structure
+
+    # Refresh the login structure on every run
+    create_login_structure()
+
     path = os.path.join('structure', 'login_structure.json')
-    if not os.path.exists(path):
-        from crawl.login_structure import create_login_structure
-        create_login_structure()
     with open(path) as f:
         return json.load(f)
 


### PR DESCRIPTION
## Summary
- regenerate login_structure.json on every run
- document login structure refresh behavior in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685b567086408320ac373e51f331077f