### PR TITLE
Fix login button xpath

### DIFF
--- a/structure/login_structure_xpath.json
+++ b/structure/login_structure_xpath.json
@@ -2,5 +2,5 @@
   "url": "https://store.bgfretail.com/websrc/deploy/index.html",
   "id_xpath": "//input[@id='mainframe.HFrameSet00.LoginFrame.form.div_login.form.edt_id:input']",
   "password_xpath": "//input[@id='mainframe.HFrameSet00.LoginFrame.form.div_login.form.edt_pw:input']",
-  "submit_xpath": "//div[@id='mainframe.HFrameSet00.LoginFrame.form.div_login.form.btn_login:iconElement']"
+  "submit_xpath": "//div[@id='mainframe.HFrameSet00.LoginFrame.form.div_login.form.btn_login:icontext']"
 }


### PR DESCRIPTION
## Summary
- correct login button XPath to use `:icontext`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685b94e628c48320b2c1db1d3297e329