### PR TITLE
Add wait-click example for login

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,7 @@ close buttons after the loops and will abort if a pop‑up cannot be dismissed.
 
 On Mondays the script navigates to **매출분석 > 중분류별 매출 구성비** using `navigate_sales_ratio.py` after closing any login pop‑ups.
 Data extracted by future features will be stored under the `sales_analysis` directory.
+
+`wait_click_login.json` provides a minimal example showing how to wait up to
+ten seconds for the login button to appear before clicking it. The snippet can
+be adapted to other actions that require an explicit wait-and-click sequence.

--- a/wait_click_login.json
+++ b/wait_click_login.json
@@ -1,0 +1,17 @@
+{
+  "name": "대기후_버튼클릭",
+  "description": "요소가 로딩될 때까지 명시적으로 대기한 뒤 로그인 버튼 클릭",
+  "steps": [
+    {
+      "action": "wait_element",
+      "by": "xpath",
+      "value": "//*[contains(@id, 'btn_login')]",
+      "timeout": 10
+    },
+    {
+      "action": "click",
+      "by": "xpath",
+      "value": "//*[contains(@id, 'btn_login')]"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add `wait_click_login.json` example for explicit wait before login
- document wait-click login snippet in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685ccb3c464483209aa70a126fb471e5