### PR TITLE
Add delay after login prompt

### DIFF
--- a/main.py
+++ b/main.py
@@ -27,6 +27,9 @@ def main():
     except Exception:
         pass
     input("Login screen displayed. Press Enter to exit...")
+    # Wait a few seconds so the window does not close immediately after
+    # submitting the prompt.
+    time.sleep(5)
     driver.quit()
 
 


### PR DESCRIPTION
## Summary
- keep the browser open briefly after the login prompt

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_685cd8e931988320ab9c7921fc2ee241