### PR TITLE
Remove unused XPath variable

### DIFF
--- a/main.py
+++ b/main.py
@@ -18,7 +18,6 @@ def main():
     driver = webdriver.Chrome()
     driver.get(url)
     # Automatically fill the ID field using the latest XPath configuration.
-    xpath_path = "/html/body/div/div/div/div[1]/div/div/div[1]/div/div/div/div[1]/div/div[5]/input"
     try:
         id_input = driver.find_element(By.XPATH, xpath_path)
         id_input.clear()


### PR DESCRIPTION
## Summary
- remove leftover XPath string from main.py

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_685cf0f9819c8320b9bd1b10b701f562