### PR TITLE
Implement JSON-driven ID input automation

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,33 +1,44 @@
-import os
 import json
 import time
 from selenium import webdriver
 from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
 
 
-def load_login_url():
-    """Return the login page URL from the stored XPath configuration."""
-    xpath_path = os.path.join("structure", "login_structure_xpath.json")
-    with open(xpath_path, "r", encoding="utf-8") as f:
-        cfg = json.load(f)
-    return cfg["url"]
+CONFIG_FILE = "nexacro_id_input_js.json"
+
+
+def load_config():
+    """Load automation configuration from ``CONFIG_FILE``."""
+    with open(CONFIG_FILE, "r", encoding="utf-8") as f:
+        return json.load(f)
 
 
 def main():
-    url = load_login_url()
+    cfg = load_config()
+    url = cfg["steps"][0]["value"]
+    id_xpath = cfg["id_xpath"]
+    js_code = cfg["steps"][3]["code"]
+
     driver = webdriver.Chrome()
     driver.get(url)
-    # Automatically fill the ID field using the latest XPath configuration.
+
+    # Wait until the Nexacro inputs are available
+    wait_cfg = cfg["steps"][1]
+    if wait_cfg.get("action") == "wait_elements_count":
+        WebDriverWait(driver, wait_cfg.get("timeout", 20)).until(
+            lambda d: len(d.find_elements(By.CLASS_NAME, wait_cfg["value"])) >= wait_cfg["count"]
+        )
+
     try:
-        id_input = driver.find_element(By.XPATH, xpath_path)
-        id_input.clear()
-        id_input.send_keys("46513")
-        time.sleep(1)
-    except Exception:
-        pass
+        id_input = driver.find_element(By.XPATH, id_xpath)
+        driver.execute_script(js_code, id_input)
+        print("\u2705 ID 입력 완료 (JavaScript 방식)")
+        time.sleep(cfg["steps"][-1].get("seconds", 2))
+    except Exception as e:
+        print(f"Failed to input ID: {e}")
+
     input("Login screen displayed. Press Enter to exit...")
-    # Wait a few seconds so the window does not close immediately after
-    # submitting the prompt.
     time.sleep(3)
     driver.quit()
 


### PR DESCRIPTION
## Summary
- load automation settings from `nexacro_id_input_js.json`
- open login URL and fill ID field via JavaScript
- wait for Nexacro input fields before executing script

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_685cf38fe2e883209011e9f1a42d76d6