### PR TITLE
Add physical input config

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,7 @@ keep the stored selectors valid.
 `wait_click_login.json` provides a minimal example showing how to wait up to
 ten seconds for the login button to appear before clicking it. The snippet can
 be adapted to other actions that require an explicit wait-and-click sequence.
+
+The `nexacro_idpw_input_physical.json` configuration showcases the same login
+flow as the JavaScript version but relies solely on Selenium's ``send_keys``
+to enter the credentials.

--- a/nexacro_idpw_input_physical.json
+++ b/nexacro_idpw_input_physical.json
@@ -1,0 +1,64 @@
+{
+  "name": "\ub124\ud0a4\uc0ac\ud06c\ub85c_IDPW_\ubb3c\ub9ac\uc785\ub825",
+  "description": "\ub124\ud0a4\uc0ac\ud06c\ub85c \ub85c\uae45\uc778: ID \ud544\ub4dc \ud074\ub9ad \u2192 ID \uc785\ub825 \u2192 \uc5d4\ud130 \u2192 PW \ud544\ub4dc \ud074\ub9ad \u2192 \uc5d4\ud130 \uc785\ub825\uae4c\uc9c0",
+  "exclusive": true,
+  "steps": [
+    {
+      "action": "open_url",
+      "value": "https://store.bgfretail.com/websrc/deploy/index.html"
+    },
+    {
+      "action": "wait_elements_count",
+      "by": "class_name",
+      "value": "nexainput",
+      "count": 2,
+      "timeout": 20
+    },
+    {
+      "action": "find_element",
+      "by": "xpath",
+      "value": "//*[@id='mainframe.HFrameSet00.LoginFrame.form.div_login.form.edt_id:input']",
+      "as": "id_input"
+    },
+    {
+      "action": "click",
+      "target": "id_input",
+      "log": "\u2705 ID \uc704\uce58 \ud074\ub9ad"
+    },
+    {
+      "action": "send_keys",
+      "target": "id_input",
+      "keys": "46513",
+      "log": "\u2705 ID \uc785\ub825"
+    },
+    {
+      "action": "send_keys",
+      "target": "id_input",
+      "keys": "ENTER",
+      "log": "\u2705 ID \uc785\ub825 \ud6c4 \uc5d4\ud130 \uc785\ub825"
+    },
+    {
+      "action": "find_element",
+      "by": "xpath",
+      "value": "//*[@id='mainframe.HFrameSet00.LoginFrame.form.div_login.form.edt_pw:input']",
+      "as": "pw_input"
+    },
+    {
+      "action": "click",
+      "target": "pw_input",
+      "log": "\u2705 \ube44\ubc00\ubc88\ud638 \uc704\uce58 \ud074\ub9ad"
+    },
+    {
+      "action": "send_keys",
+      "target": "pw_input",
+      "keys": "ENTER",
+      "log": "\u2705 \ube44\ubc00\ubc88\ud638 \uc785\ub825 \ud6c4 \uc5d4\ud130 \uc785\ub825"
+    },
+    {
+      "action": "sleep",
+      "seconds": 2
+    }
+  ],
+  "id_xpath": "//*[@id='mainframe.HFrameSet00.LoginFrame.form.div_login.form.edt_id:input']",
+  "pw_xpath": "//*[@id='mainframe.HFrameSet00.LoginFrame.form.div_login.form.edt_pw:input']"
+}


### PR DESCRIPTION
## Summary
- document physical key demo config
- add `nexacro_idpw_input_physical.json` with Selenium send_keys steps

## Testing
- `python -m py_compile aaa/main.py`


------
https://chatgpt.com/codex/tasks/task_e_685d423c27dc83208af16d50cb39e458