### PR TITLE
Switch main config to physical

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,7 +7,7 @@ from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.common.keys import Keys
 
 
-CONFIG_FILE = "nexacro_idpw_input_js.json"
+CONFIG_FILE = "nexacro_idpw_input_physical.json"
 
 
 def load_config():


### PR DESCRIPTION
## Summary
- use `nexacro_idpw_input_physical.json` as the default config

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_685d44a391408320b8f6d8510c9a7114