### PR TITLE
Support variable substitution in send_keys

### DIFF
--- a/main.py
+++ b/main.py
@@ -46,6 +46,11 @@ def run_step(driver, step, elements, env):
     elif action == "send_keys":
         elem = elements[step["target"]]
         keys = step["keys"]
+
+        # \u2705 \ubcc0\uc218 \ud070\uc791 \ucc98\ub9ac
+        if isinstance(keys, str):
+            keys = env.get(keys.strip("${}"), keys)
+
         if isinstance(keys, list):
             for item in keys:
                 k = item["key"]


### PR DESCRIPTION
## Summary
- replace `send_keys` handling to substitute environment variables

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_685d5afbda4c8320b263699c553bd2e0