### PR TITLE
Update login config to use send_keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ keep the stored selectors valid.
 ten seconds for the login button to appear before clicking it. The snippet can
 be adapted to other actions that require an explicit wait-and-click sequence.
 
-The `nexacro_idpw_input_physical.json` configuration showcases the same login
-flow as the JavaScript version but relies solely on Selenium's ``send_keys``
-to enter the credentials.
+`nexacro_idpw_input_js.json` demonstrates variable substitution for the
+credentials and sends the Enter key three times after typing the password.
+`nexacro_idpw_input_physical.json` performs a similar sequence but includes
+explicit clicks on each field before typing.

--- a/nexacro_idpw_input_js.json
+++ b/nexacro_idpw_input_js.json
@@ -1,6 +1,6 @@
 {
   "name": "넥사크로_IDPW_입력_JS",
-  "description": "넥사크로 기반 페이지에서 ID, PW 입력 필드를 XPath로 찾고, JavaScript로 각각 강제 입력 후 엔터 키 입력",
+  "description": "넥사크로 기반 페이지에서 ID, PW 입력 필드를 XPath로 찾고, `send_keys` 로 값을 입력한 뒤 엔터 키를 세 번 보내는 예제",
   "exclusive": true,
   "steps": [
     {
@@ -21,13 +21,10 @@
       "as": "id_input"
     },
     {
-      "action": "script",
-      "code": "arguments[0].value = '46513';",
-      "target": "id_input"
-    },
-    {
-      "action": "log",
-      "message": "✅ ID 입력 완료 (JavaScript 방식)"
+      "action": "send_keys",
+      "target": "id_input",
+      "keys": "${LOGIN_ID}",
+      "log": "✅ ID 입력 완료"
     },
     {
       "action": "find_element",
@@ -36,13 +33,10 @@
       "as": "pw_input"
     },
     {
-      "action": "script",
-      "code": "arguments[0].value = '1113';",
-      "target": "pw_input"
-    },
-    {
-      "action": "log",
-      "message": "✅ 비밀번호 입력 완료"
+      "action": "send_keys",
+      "target": "pw_input",
+      "keys": "${LOGIN_PW}",
+      "log": "✅ 비밀번호 입력 완료"
     },
     {
       "action": "send_keys",


### PR DESCRIPTION
## Summary
- update `nexacro_idpw_input_js.json` to use `send_keys` and variable substitution
- clarify README about new config behavior

## Testing
- `python -m py_compile main.py`
- `python main.py` *(fails: unable to obtain driver for chrome)*

------
https://chatgpt.com/codex/tasks/task_e_685d5c9a12dc83208012d2beaf32ff57