### PR TITLE
Implement login sequence and improve focus handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ keep the stored selectors valid.
 ten seconds for the login button to appear before clicking it. The snippet can
 be adapted to other actions that require an explicit wait-and-click sequence.
 
-`nexacro_idpw_input_js.json` demonstrates variable substitution for the
-credentials and sends the Enter key three times after typing the password.
-`nexacro_idpw_input_physical.json` performs a similar sequence but includes
-explicit clicks on each field before typing.
+`login_sequence.json` defines the basic login automation. It loads the
+credentials from `.env` and sends the Enter key three times after typing the
+password. `nexacro_idpw_input_physical.json` performs a similar sequence but
+includes explicit clicks on each field before typing.

--- a/login_sequence.json
+++ b/login_sequence.json
@@ -1,0 +1,18 @@
+{
+  "name": "넥사크로 로그인 자동화",
+  "description": "ID/PW 입력 후 엔터 3회로 로그인 처리",
+  "steps": [
+    {"action": "open_url", "value": "https://store.bgfretail.com/websrc/deploy/index.html"},
+    {"action": "wait_elements_count", "by": "class_name", "value": "nexainput", "count": 2, "timeout": 20},
+    {"action": "find_element", "by": "xpath", "value": "//input[@id='mainframe.HFrameSet00.LoginFrame.form.div_login.form.edt_id:input']", "as": "id_input"},
+    {"action": "send_keys", "target": "id_input", "keys": "${LOGIN_ID}", "log": "✅ ID 입력 완료"},
+    {"action": "find_element", "by": "xpath", "value": "//*[@id='mainframe.HFrameSet00.LoginFrame.form.div_login.form.edt_pw:input']", "as": "pw_input"},
+    {"action": "send_keys", "target": "pw_input", "keys": "${LOGIN_PW}", "log": "✅ 비밀번호 입력 완료"},
+    {"action": "send_keys", "target": "pw_input", "keys": [
+      {"key": "ENTER", "delay": 1},
+      {"key": "ENTER", "delay": 1},
+      {"key": "ENTER"}
+    ], "log": "✅ 엔터 3회 입력"},
+    {"action": "sleep", "seconds": 2}
+  ]
+}

--- a/main.py
+++ b/main.py
@@ -8,7 +8,7 @@ from selenium.webdriver.support.ui import WebDriverWait
 from dotenv import load_dotenv
 import os
 
-CONFIG_FILE = "nexacro_idpw_input_js.json"
+CONFIG_FILE = "login_sequence.json"
 
 
 def load_config():
@@ -48,9 +48,6 @@ def run_step(driver, step, elements, env):
         keys = step["keys"]
 
         # \u2705 \ubcc0\uc218 \ud070\uc791 \ucc98\ub9ac
-        if isinstance(keys, str):
-            keys = env.get(keys.strip("${}"), keys)
-
         if isinstance(keys, list):
             for item in keys:
                 k = item["key"]
@@ -61,7 +58,9 @@ def run_step(driver, step, elements, env):
                 if "delay" in item:
                     time.sleep(item["delay"])
         else:
-            elem.send_keys(keys)
+            if isinstance(keys, str):
+                keys = env.get(keys.strip("${}"), keys)
+            ActionChains(driver).move_to_element(elem).click().send_keys(keys).perform()
 
     elif action == "script":
         code = step["code"]


### PR DESCRIPTION
## Summary
- add `login_sequence.json` with Nexacro login steps
- default to `login_sequence.json` in `main.py`
- ensure send_keys clicks target element before typing
- document new JSON config in README

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_685d666d87188320b988bf0add8d8bd9