### PR TITLE
Modify login sequence to press Enter twice

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,6 @@ ten seconds for the login button to appear before clicking it. The snippet can
 be adapted to other actions that require an explicit wait-and-click sequence.
 
 `login_sequence.json` defines the basic login automation. It loads the
-credentials from `.env` and sends the Enter key three times after typing the
+credentials from `.env` and sends the Enter key twice after typing the
 password. `nexacro_idpw_input_physical.json` performs a similar sequence but
 includes explicit clicks on each field before typing.

--- a/login_sequence.json
+++ b/login_sequence.json
@@ -1,6 +1,6 @@
 {
   "name": "넥사크로 로그인 자동화",
-  "description": "ID/PW 입력 후 엔터 3회로 로그인 처리",
+  "description": "ID/PW 입력 후 엔터 2회로 로그인 처리",
   "steps": [
     {"action": "open_url", "value": "https://store.bgfretail.com/websrc/deploy/index.html"},
     {"action": "wait_elements_count", "by": "class_name", "value": "nexainput", "count": 2, "timeout": 20},
@@ -10,9 +10,8 @@
     {"action": "send_keys", "target": "pw_input", "keys": "${LOGIN_PW}", "log": "✅ 비밀번호 입력 완료"},
     {"action": "send_keys", "target": "pw_input", "keys": [
       {"key": "ENTER", "delay": 1},
-      {"key": "ENTER", "delay": 1},
       {"key": "ENTER"}
-    ], "log": "✅ 엔터 3회 입력"},
+    ], "log": "✅ 엔터 2회 입력"},
     {"action": "sleep", "seconds": 2}
   ]
 }


### PR DESCRIPTION
## Summary
- update README to describe two Enter key presses
- change `login_sequence.json` to send Enter twice instead of three times

## Testing
- `python -m py_compile main.py login_runner.py`
- `python -m json.tool login_sequence.json`

------
https://chatgpt.com/codex/tasks/task_e_685dbfa6b20083208ecd15d0f0bdbd30