### PR TITLE
Add snippet processing utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,18 @@ be adapted to other actions that require an explicit wait-and-click sequence.
 credentials from `.env` and sends the Enter key twice after typing the
 password. `nexacro_idpw_input_physical.json` performs a similar sequence but
 includes explicit clicks on each field before typing.
+
+## Generating Commands from Snippet Data
+
+Use `snippet_to_json.py` to convert DOM snippet results into a JSON command sequence. The input file must contain an `id목록` array with element IDs. If a value includes a tag after a colon (e.g. `btn_search:button`), an extra click step is inserted for buttons.
+
+Example:
+```json
+{"id목록": ["btn_search:button", "edt_id:input", "txt_pw:input"]}
+```
+
+Generate the commands:
+```bash
+python snippet_to_json.py sample_snippet.json commands_output.json
+```
+

--- a/sample_snippet.json
+++ b/sample_snippet.json
@@ -1,0 +1,1 @@
+{"id목록": ["btn_search:button", "edt_id:input", "txt_pw:input"]}

--- a/snippet_to_json.py
+++ b/snippet_to_json.py
@@ -1,0 +1,46 @@
+import json
+import sys
+from pathlib import Path
+
+
+def parse_id_entry(entry):
+    """Split an entry like 'edt_id:input' into (id, tag)."""
+    if ':' in entry:
+        elem_id, tag = entry.split(':', 1)
+    else:
+        elem_id, tag = entry, None
+    return elem_id, tag
+
+
+def generate_steps(ids):
+    steps = []
+    for entry in ids:
+        elem_id, tag = parse_id_entry(entry)
+        alias = elem_id
+        steps.append({
+            "action": "find_element",
+            "by": "xpath",
+            "value": f"//*[@id='{elem_id}']",
+            "as": alias
+        })
+        if tag == 'button':
+            steps.append({
+                "action": "click",
+                "target": alias,
+                "log": f"✅ {alias} 클릭"
+            })
+    return steps
+
+
+def main(input_path, output_path):
+    data = json.loads(Path(input_path).read_text(encoding='utf-8'))
+    ids = data.get('id목록') or data.get('ids') or []
+    steps = generate_steps(ids)
+    Path(output_path).write_text(json.dumps({"steps": steps}, ensure_ascii=False, indent=2), encoding='utf-8')
+
+
+if __name__ == '__main__':
+    if len(sys.argv) != 3:
+        print('Usage: python snippet_to_json.py <snippet.json> <output.json>')
+        sys.exit(1)
+    main(sys.argv[1], sys.argv[2])


### PR DESCRIPTION
## Summary
- add `snippet_to_json.py` for converting snippet data to automation steps
- include example `sample_snippet.json`
- document snippet workflow in README

## Testing
- `python -m py_compile snippet_to_json.py`

------
https://chatgpt.com/codex/tasks/task_e_685dc73a0c2083209e4dc5696601e490