### PR TITLE
Add mid-category sales automation example

### DIFF
--- a/"b/modules/\353\247\244\354\266\234\353\266\204\354\204\235/\354\244\221\353\266\204\353\245\230\353\263\204\353\247\244\354\266\234\352\265\254\354\204\261.json"
+++ b/"b/modules/\353\247\244\354\266\234\353\266\204\354\204\235/\354\244\221\353\266\204\353\245\230\353\263\204\353\247\244\354\266\234\352\265\254\354\204\261.json"
@@ -1,0 +1,26 @@
+{
+  "steps": [
+    {
+      "action": "find_element",
+      "by": "xpath",
+      "value": "//*[@id='mainframe.HFrameSet00.VFrameSet00.TopFrame.form.div_topMenu.form.STMB000_M0:icontext']/div",
+      "as": "매출분석메뉴"
+    },
+    {
+      "action": "click",
+      "target": "매출분석메뉴",
+      "log": "✅ 매출분석 클릭"
+    },
+    {
+      "action": "find_element",
+      "by": "xpath",
+      "value": "//*[@id='mainframe.HFrameSet00.VFrameSet00.TopFrame.form.pdiv_topMenu_STMB000_M0.form.STMB011_M0:text']",
+      "as": "중분류매출"
+    },
+    {
+      "action": "click",
+      "target": "중분류매출",
+      "log": "✅ 중분류별 매출 구성 클릭"
+    }
+  ]
+}

--- a/"b/modules/\353\247\244\354\266\234\353\266\204\354\204\235/run_\354\244\221\353\266\204\353\245\230\353\263\204\353\247\244\354\266\234.py"
+++ b/"b/modules/\353\247\244\354\266\234\353\266\204\354\204\235/run_\354\244\221\353\266\204\353\245\230\353\263\204\353\247\244\354\266\234.py"
@@ -1,0 +1,24 @@
+import json
+from selenium import webdriver
+from login_runner import run_step, load_env
+
+
+def run_script(config_path):
+    with open(config_path, "r", encoding="utf-8") as f:
+        steps = json.load(f)["steps"]
+    env = load_env()
+    options = webdriver.ChromeOptions()
+    driver = webdriver.Chrome(options=options)
+    elements = {}
+    for step in steps:
+        try:
+            run_step(driver, step, elements, env)
+        except Exception as e:
+            print(f"❌ Step 실패: {step.get('action')} → {e}")
+            break
+    input("⏸ 자동화 완료. Enter를 누르면 종료됩니다.")
+    driver.quit()
+
+
+if __name__ == "__main__":
+    run_script("modules/매출분석/중분류별매출구성.json")


### PR DESCRIPTION
## Summary
- automate mid-category sales menu in Nexacro
- add config and runner

## Testing
- `python -m py_compile modules/매출분석/run_중분류별매출.py`


------
https://chatgpt.com/codex/tasks/task_e_685dd8b973a083208c2d8bb2cc7afe57