### PR TITLE
Add snippet-to-command conversion and inventory example

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,23 @@ Generate the commands:
 python snippet_to_json.py sample_snippet.json commands_output.json
 ```
 
+
+## Quick Inventory Command Generation
+
+Use `snippet_to_command.py` when you have a list of element IDs and need to build
+an automation sequence quickly. The script reads a snippet file containing
+`id목록` and creates a command JSON following simple rules:
+
+- IDs starting with `btn_` get a `click` step after locating the element.
+- IDs starting with `edt_` or `txt_` include a `send_keys` placeholder.
+- All other IDs only generate a `find_element` step.
+
+Example:
+```bash
+python snippet_to_command.py modules/inventory/inventory_list_snippet.json \
+    modules/inventory/inventory_list_cmd.json
+```
+Run the resulting automation:
+```bash
+python modules/inventory/run_inventory_list.py
+```

--- a/modules/inventory/inventory_list_cmd.json
+++ b/modules/inventory/inventory_list_cmd.json
@@ -1,0 +1,39 @@
+{
+  "steps": [
+    {
+      "action": "find_element",
+      "by": "xpath",
+      "value": "//*[@id='btn_search']",
+      "as": "btn_search"
+    },
+    {
+      "action": "click",
+      "target": "btn_search",
+      "log": "✅ btn_search 클릭"
+    },
+    {
+      "action": "find_element",
+      "by": "xpath",
+      "value": "//*[@id='edt_productName']",
+      "as": "edt_productName"
+    },
+    {
+      "action": "send_keys",
+      "target": "edt_productName",
+      "keys": "",
+      "log": "✅ edt_productName 입력"
+    },
+    {
+      "action": "find_element",
+      "by": "xpath",
+      "value": "//*[@id='txt_qty']",
+      "as": "txt_qty"
+    },
+    {
+      "action": "send_keys",
+      "target": "txt_qty",
+      "keys": "",
+      "log": "✅ txt_qty 입력"
+    }
+  ]
+}

--- a/modules/inventory/inventory_list_snippet.json
+++ b/modules/inventory/inventory_list_snippet.json
@@ -1,0 +1,1 @@
+{"id목록": ["btn_search", "edt_productName", "txt_qty"]}

--- a/modules/inventory/run_inventory_list.py
+++ b/modules/inventory/run_inventory_list.py
@@ -1,0 +1,24 @@
+import json
+from selenium import webdriver
+from login_runner import run_step, load_env
+
+
+def run_script(config_path):
+    with open(config_path, "r", encoding="utf-8") as f:
+        steps = json.load(f)["steps"]
+    env = load_env()
+    options = webdriver.ChromeOptions()
+    driver = webdriver.Chrome(options=options)
+    elements = {}
+    for step in steps:
+        try:
+            run_step(driver, step, elements, env)
+        except Exception as e:
+            print(f"❌ Step failed: {step.get('action')} → {e}")
+            break
+    input("⏸ Automation complete. Press Enter to exit.")
+    driver.quit()
+
+
+if __name__ == "__main__":
+    run_script("modules/inventory/inventory_list_cmd.json")

--- a/snippet_to_command.py
+++ b/snippet_to_command.py
@@ -1,0 +1,53 @@
+import json
+import sys
+from pathlib import Path
+
+
+def load_snippet_ids(path):
+    """Load the id list from a snippet JSON file."""
+    data = json.loads(Path(path).read_text(encoding="utf-8"))
+    return data.get("id목록") or data.get("ids") or []
+
+
+def generate_commands(ids):
+    steps = []
+    for entry in ids:
+        # handle entries like "btn_search:button" by stripping tag
+        elem_id = entry.split(":", 1)[0]
+        alias = elem_id
+        steps.append({
+            "action": "find_element",
+            "by": "xpath",
+            "value": f"//*[@id='{elem_id}']",
+            "as": alias
+        })
+        if elem_id.startswith("btn_"):
+            steps.append({
+                "action": "click",
+                "target": alias,
+                "log": f"✅ {alias} 클릭"
+            })
+        elif elem_id.startswith("edt_") or elem_id.startswith("txt_"):
+            steps.append({
+                "action": "send_keys",
+                "target": alias,
+                "keys": "",
+                "log": f"✅ {alias} 입력"
+            })
+    return steps
+
+
+def main(snippet_path, output_path):
+    ids = load_snippet_ids(snippet_path)
+    steps = generate_commands(ids)
+    Path(output_path).write_text(
+        json.dumps({"steps": steps}, ensure_ascii=False, indent=2),
+        encoding="utf-8"
+    )
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print("Usage: python snippet_to_command.py <snippet.json> <output.json>")
+        sys.exit(1)
+    main(sys.argv[1], sys.argv[2])


### PR DESCRIPTION
## Summary
- add `snippet_to_command.py` to convert snippet id lists into Selenium commands
- create new `modules/inventory` example using the converter
- document the new workflow in README

## Testing
- `python -m py_compile snippet_to_command.py modules/inventory/run_inventory_list.py`
- `python snippet_to_command.py modules/inventory/inventory_list_snippet.json modules/inventory/inventory_list_cmd.json`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_685de2e2c2048320a574e58e447e20de