### PR TITLE
Add mid-category sales command and update scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ To launch the mid-category sales automation after logging in, run:
 ```bash
 python modules/sales_analysis/run_mid_category_sales.py
 ```
+The command sequence used by this script is stored in
+`modules/sales_analysis/mid_category_sales_cmd.json`.
 
 
 The structure files in the `structure` directory describe the XPath selectors

--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@ import json
 
 
 def run_sales_analysis(driver):
-    with open("modules/sales_analysis/mid_category_sales.json", "r", encoding="utf-8") as f:
+    with open("modules/sales_analysis/mid_category_sales_cmd.json", "r", encoding="utf-8") as f:
         steps = json.load(f)["steps"]
     env = load_env()
     elements = {}

--- a/modules/sales_analysis/mid_category_sales_cmd.json
+++ b/modules/sales_analysis/mid_category_sales_cmd.json
@@ -1,0 +1,55 @@
+{
+  "steps": [
+    {
+      "action": "find_element",
+      "by": "xpath",
+      "value": "//*[@id='mainframe.HFrameSet00.VFrameSet00.TopFrame.form.div_topMenu.form.STMB000_M0:icontext']/div",
+      "as": "salesAnalysisMenu"
+    },
+    {
+      "action": "click",
+      "target": "salesAnalysisMenu",
+      "log": "✅ Clicked Sales Analysis menu"
+    },
+    {
+      "action": "find_element",
+      "by": "xpath",
+      "value": "//*[@id='mainframe.HFrameSet00.VFrameSet00.TopFrame.form.pdiv_topMenu_STMB000_M0.form.STMB011_M0:text']",
+      "as": "midCategorySales"
+    },
+    {
+      "action": "click",
+      "target": "midCategorySales",
+      "log": "✅ Clicked Mid-category Sales Composition"
+    },
+    {
+      "action": "wait_elements_count",
+      "by": "xpath",
+      "value": "//*[@id='mainframe.HFrameSet00.VFrameSet00.FrameSet.STMB011_M0.form.div_workForm.form.div2.form.gdList.body.gridrow_0.cell_0_0:text']",
+      "count": 1,
+      "timeout": 10,
+      "log": "✅ Waited for mid-category row to load"
+    },
+    {
+      "action": "find_element",
+      "by": "xpath",
+      "value": "//*[@id='mainframe.HFrameSet00.VFrameSet00.FrameSet.STMB011_M0.form.div_workForm.form.div2.form.gdList.body.gridrow_0.cell_0_0:text']",
+      "as": "category001"
+    },
+    {
+      "action": "click",
+      "target": "category001",
+      "log": "✅ Clicked category 001"
+    },
+    {
+      "action": "extract_texts",
+      "from": {
+        "xpath_prefix": "//*[@id='mainframe.HFrameSet00.VFrameSet00.FrameSet.STMB011_M0.form.div_workForm.form.div3.form.gdList2.body.gridrow_",
+        "xpath_suffix": ".cell_0_0:text"
+      },
+      "rows": 20,
+      "save_to": "output/category_001_detail.txt",
+      "log": "✅ Extracted detail rows to text file"
+    }
+  ]
+}

--- a/modules/sales_analysis/run_mid_category_sales.py
+++ b/modules/sales_analysis/run_mid_category_sales.py
@@ -21,4 +21,4 @@ def run_script(config_path):
 
 
 if __name__ == "__main__":
-    run_script("modules/sales_analysis/mid_category_sales.json")
+    run_script("modules/sales_analysis/mid_category_sales_cmd.json")


### PR DESCRIPTION
## Summary
- implement mid_category_sales_cmd.json with wait for grid load
- reference the new command file from the sales runner and main
- document the new command file in README

## Testing
- `python -m py_compile main.py modules/sales_analysis/run_mid_category_sales.py`
- `python -m json.tool modules/sales_analysis/mid_category_sales_cmd.json`

------
https://chatgpt.com/codex/tasks/task_e_685ded8318b08320ba05154678dac44e