### PR TITLE
Remove headless option from Chrome setup

### DIFF
--- a/main.py
+++ b/main.py
@@ -21,7 +21,7 @@ def main():
     options.add_argument("--disable-gpu")
     options.add_argument("--window-size=1920,1080")
     options.add_argument("--no-sandbox")
-    options.add_argument("--headless=new")  # headless 환경에서 실행 가능
+    # options.add_argument("--headless=new")  # headless 환경에서 실행 가능
 
     driver = webdriver.Chrome(options=options)  # ✅ 자동 드라이버 탐색
     run_login(driver)


### PR DESCRIPTION
## Summary
- comment out the headless Chrome option in `main.py`

## Testing
- `python -m py_compile main.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685e11b4e3fc832099bb5b238402dce4