### PR TITLE
Fix mid-category detail extraction

### DIFF
--- a/modules/sales_analysis/mid_category_sales_cmd.json
+++ b/modules/sales_analysis/mid_category_sales_cmd.json
@@ -44,12 +44,12 @@
     {
       "action": "extract_texts",
       "from": {
-        "xpath_prefix": "//*[@id=\"mainframe.HFrameSet00.VFrameSet00.FrameSet.STMB011_M0.form.div_workForm.form.div2.form.gdDetail.body\"]",
-        "xpath_suffix": ""
+        "xpath_prefix": "//*[@id=\"mainframe.HFrameSet00.VFrameSet00.FrameSet.STMB011_M0.form.div_workForm.form.div2.form.gdDetail.body.gridrow_",
+        "xpath_suffix": ".cell_0_1:text\"]"
       },
-      "rows": 1,
+      "rows": "auto",
       "save_to": "output/category_001_detail.txt",
-      "log": "✅ 상세 텍스트 저장 완료"
+      "log": "✅ gdDetail 반복 행 텍스트 자동 추출 완료"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- update XPath prefix and suffix for gdDetail rows
- fetch all rows automatically during extraction

## Testing
- `python -m py_compile modules/sales_analysis/run_mid_category_sales.py main.py login_runner.py snippet_to_json.py snippet_to_command.py modules/inventory/*.py`

------
https://chatgpt.com/codex/tasks/task_e_685e1359670c8320b6d6079a310cb72d