### PR TITLE
Add SSV post-processing step

### DIFF
--- a/main.py
+++ b/main.py
@@ -27,6 +27,17 @@ def main():
     run_login(driver)
     run_sales_analysis(driver)
 
+    from parse_and_save import parse_ssv, save_filtered_rows
+    from pathlib import Path
+
+    ssv_path = "output/category_001_detail.txt"
+    out_path = "output/category_001_filtered.txt"
+    if Path(ssv_path).exists():
+        with open(ssv_path, "r", encoding="utf-8") as f:
+            rows = parse_ssv(f.read())
+        save_filtered_rows(rows, out_path)
+        print(f"✅ 필터링 완료: {out_path}")
+
     input("⏸ 로그인 화면 유지 중. Enter를 누르면 종료됩니다.")
     driver.quit()
 

--- a/parse_and_save.py
+++ b/parse_and_save.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+
+def parse_ssv(ssv_text):
+    blocks = ssv_text.split("\x1e")
+    header_line = next(line for line in blocks if "ITEM_CD" in line)
+    col_names = [x.split(":")[0] for x in header_line.split("\x1f")[1:]]
+
+    result = []
+    for line in blocks:
+        if line.startswith("N\x1f"):
+            values = line.split("\x1f")[1:]
+            row = {col: values[i] if i < len(values) else "" for i, col in enumerate(col_names)}
+            result.append(row)
+    return result
+
+
+def save_filtered_rows(rows, path, fields=["ITEM_CD", "ITEM_NM", "STOCK_QTY"]):
+    filtered = [r for r in rows if r.get("STOCK_QTY", "").strip() == "0"]
+    lines = [", ".join(r.get(f, "") for f in fields) for r in filtered]
+
+    Path(path).parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        f.write("\n".join(lines))


### PR DESCRIPTION
## Summary
- implement `parse_and_save.py` with SSV parsing and filtering helpers
- run parsing step after `run_sales_analysis` in `main.py`

## Testing
- `python -m py_compile main.py parse_and_save.py modules/sales_analysis/run_mid_category_sales.py login_runner.py modules/inventory/run_inventory_list.py snippet_to_command.py snippet_to_json.py`


------
https://chatgpt.com/codex/tasks/task_e_685e268711b8832092bb7dbaf62507c5