### PR TITLE
Add XPath debug output and limit rows

### DIFF
--- a/login_runner.py
+++ b/login_runner.py
@@ -67,20 +67,25 @@ def run_step(driver, step, elements, env):
             i = 0
             while True:
                 path = f"{prefix}{i}{suffix}"
+                print(f"🔍 시도 중인 XPath: {path}")
                 try:
                     elem = driver.find_element(By.XPATH, path)
+                    print(f"✅ 텍스트 발견: {elem.text.strip()}")
                     results.append(elem.text.strip())
                     i += 1
-                except Exception:
+                except Exception as e:
+                    print(f"❌ 텍스트 없음 @ {path} → {e}")
                     break
         else:
             for i in range(row_count):
                 path = f"{prefix}{i}{suffix}"
+                print(f"🔍 시도 중인 XPath: {path}")
                 try:
                     elem = driver.find_element(By.XPATH, path)
+                    print(f"✅ 텍스트 발견: {elem.text.strip()}")
                     results.append(elem.text.strip())
                 except Exception as e:
-                    print(f"❌ extract_texts row {i} → {e}")
+                    print(f"❌ 텍스트 없음 @ {path} → {e}")
                     break
         outfile = step.get("save_to")
         if outfile:

--- a/modules/sales_analysis/mid_category_sales_cmd.json
+++ b/modules/sales_analysis/mid_category_sales_cmd.json
@@ -47,7 +47,7 @@
         "xpath_prefix": "//*[@id=\"mainframe.HFrameSet00.VFrameSet00.FrameSet.STMB011_M0.form.div_workForm.form.div2.form.gdDetail.body.gridrow_",
         "xpath_suffix": ".cell_0_1:text\"]"
       },
-      "rows": "auto",
+      "rows": 5,
       "save_to": "output/category_001_detail.txt",
       "log": "✅ gdDetail 반복 행 텍스트 자동 추출 완료"
     }

--- a/modules/sales_analysis/mid_category_sales_cmd_debug.json
+++ b/modules/sales_analysis/mid_category_sales_cmd_debug.json
@@ -52,7 +52,7 @@
         "xpath_prefix": "//*[@id=\"mainframe.HFrameSet00.VFrameSet00.FrameSet.STMB011_M0.form.div_workForm.form.div2.form.gdDetail.body.gridrow_",
         "xpath_suffix": ".cell_0_1:text\"]"
       },
-      "rows": "auto",
+      "rows": 5,
       "save_to": "output/category_001_detail.txt",
       "log": "📦 gdDetail 반복행 텍스트 추출 완료 → category_001_detail.txt"
     }


### PR DESCRIPTION
## Summary
- add detailed debugging logs in `login_runner.py` for XPath attempts and text extraction
- fix mid category sales command configs to use a constant `rows` value of 5

## Testing
- `python -m py_compile login_runner.py modules/sales_analysis/run_mid_category_sales.py parse_and_save.py`

------
https://chatgpt.com/codex/tasks/task_e_685e358bb9a08320b8597614d1b553bc