### PR TITLE
Implement SSV filtering and add unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ This project opens the BGF Retail store login page using Selenium. It is a simpl
 
 The mid-category sales automation is now executed directly from `main.py` using
 `modules/sales_analysis/mid_category_sales_ssv.json` to capture the dataset.
+After downloading the SSV response, `parse_and_save.py` parses the data and
+stores rows with zero stock quantity in `output/category_001_filtered.txt`.
 
 
 The structure files in the `structure` directory describe the XPath selectors

--- a/main.py
+++ b/main.py
@@ -30,7 +30,12 @@ def run_sales_analysis(driver):
             from parse_and_save import parse_ssv, save_filtered_rows
             with open(step["input"], "r", encoding="utf-8") as f:
                 rows = parse_ssv(f.read())
-            save_filtered_rows(rows, step["save_to"], step["fields"])
+            save_filtered_rows(
+                rows,
+                step["save_to"],
+                fields=step.get("fields"),
+                filter_dict=step.get("filter"),
+            )
 
         if log:
             print(log)

--- a/tests/test_parse_and_save.py
+++ b/tests/test_parse_and_save.py
@@ -1,0 +1,17 @@
+from parse_and_save import parse_ssv
+
+
+def test_parse_ssv_basic():
+    ssv = (
+        "Dataset:ds1\x1e"
+        "H\x1fITEM_CD:STRING\x1fITEM_NM:STRING\x1fSTOCK_QTY:STRING\x1e"
+        "N\x1f1001\x1fItem1\x1f0\x1e"
+        "N\x1f1002\x1fItem2\x1f5\x1e"
+    )
+    rows = parse_ssv(ssv)
+    assert rows == [
+        {"ITEM_CD": "1001", "ITEM_NM": "Item1", "STOCK_QTY": "0"},
+        {"ITEM_CD": "1002", "ITEM_NM": "Item2", "STOCK_QTY": "5"},
+    ]
+
+


### PR DESCRIPTION
## Summary
- document usage of SSV parser in README
- expand `parse_ssv` and `save_filtered_rows` with docstrings and filtering support
- update `main.py` to pass filtering arguments
- add pytest for `parse_ssv`

## Testing
- `pip install -r requirements.txt`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e4d8aac68832086a7dc6b8acdb352