### PR TITLE
Add waits in sales analysis navigation

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from login_runner import run_login
 import json
+import time
 
 
 def run_sales_analysis(driver):
@@ -22,18 +23,20 @@ def run_sales_analysis(driver):
         log = step.get("log")
 
         if action == "navigate_menu":
-            # 매출분석 메뉴 클릭
+            print("\U0001F7E1 매출분석 메뉴 클릭")
             driver.find_element(By.XPATH, '//*[@id="mainframe.HFrameSet00.VFrameSet00.TopFrame.form.div_topMenu.form.STMB000_M0:icontext"]/div').click()
+            time.sleep(1)
 
-            # 중분류 구성비 메뉴가 나타날 때까지 최대 5초 대기
+            print("\U0001F7E1 중분류 메뉴 등장 대기")
             WebDriverWait(driver, 5).until(
                 EC.presence_of_element_located((By.XPATH, '//*[@id="mainframe.HFrameSet00.VFrameSet00.TopFrame.form.pdiv_topMenu_STMB000_M0.form.STMB011_M0:text"]'))
             )
+            time.sleep(0.5)
 
-            # 중분류 구성비 메뉴 클릭
+            print("\U0001F7E2 중분류별 매출 구성비 클릭")
             driver.find_element(By.XPATH, '//*[@id="mainframe.HFrameSet00.VFrameSet00.TopFrame.form.pdiv_topMenu_STMB000_M0.form.STMB011_M0:text"]').click()
+            time.sleep(2)
 
-            # 중분류 셀 로딩 대기
             WebDriverWait(driver, 5).until(
                 EC.presence_of_element_located((By.XPATH, '//*[@id="mainframe.HFrameSet00.VFrameSet00.FrameSet.STMB011_M0.form.div_workForm.form.div2.form.gdList.body.gridrow_0.cell_0_0"]'))
             )


### PR DESCRIPTION
## Summary
- add time import
- pause between navigation actions so the page can stabilize

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e59efbc1483208657a625b7def204