### PR TITLE
Add delay after clicking mid category

### DIFF
--- a/main.py
+++ b/main.py
@@ -42,6 +42,9 @@ def run_sales_analysis(driver):
             )
         elif action == "click":
             driver.find_element("xpath", step["target_xpath"]).click()
+        elif action == "sleep":
+            # Allow pauses between actions when server responses are required
+            time.sleep(step.get("seconds", 1))
         elif action == "extract_network_response":
             extract_ssv_from_cdp(driver, keyword=step["match"], save_to=step["save_to"])
         elif action == "parse_ssv":

--- a/modules/sales_analysis/mid_category_sales_ssv.json
+++ b/modules/sales_analysis/mid_category_sales_ssv.json
@@ -19,6 +19,10 @@
         "log": "✅ 중분류 코드 001 클릭 완료"
       },
       {
+        "action": "sleep",
+        "seconds": 1.5
+      },
+      {
         "action": "extract_network_response",
       "match": "selDetailSearch",
       "save_to": "output/category_001_detail.txt",


### PR DESCRIPTION
## Summary
- support `sleep` action in `run_sales_analysis`
- wait 1.5 seconds after mid-category click

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e675b242c8320b7393546315e44b0