### PR TITLE
Refactor sales navigation into separate module

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,7 +1,4 @@
 from selenium import webdriver
-from selenium.webdriver.common.by import By
-from selenium.webdriver.support.ui import WebDriverWait
-from selenium.webdriver.support import expected_conditions as EC
 from login_runner import run_login
 import json
 import time
@@ -23,23 +20,8 @@ def run_sales_analysis(driver):
         log = step.get("log")
 
         if action == "navigate_menu":
-            print("\U0001F7E1 매출분석 메뉴 클릭")
-            driver.find_element(By.XPATH, '//*[@id="mainframe.HFrameSet00.VFrameSet00.TopFrame.form.div_topMenu.form.STMB000_M0:icontext"]/div').click()
-            time.sleep(1)
-
-            print("\U0001F7E1 중분류 메뉴 등장 대기")
-            WebDriverWait(driver, 5).until(
-                EC.presence_of_element_located((By.XPATH, '//*[@id="mainframe.HFrameSet00.VFrameSet00.TopFrame.form.pdiv_topMenu_STMB000_M0.form.STMB011_M0:text"]'))
-            )
-            time.sleep(0.5)
-
-            print("\U0001F7E2 중분류별 매출 구성비 클릭")
-            driver.find_element(By.XPATH, '//*[@id="mainframe.HFrameSet00.VFrameSet00.TopFrame.form.pdiv_topMenu_STMB000_M0.form.STMB011_M0:text"]').click()
-            time.sleep(2)
-
-            WebDriverWait(driver, 5).until(
-                EC.presence_of_element_located((By.XPATH, '//*[@id="mainframe.HFrameSet00.VFrameSet00.FrameSet.STMB011_M0.form.div_workForm.form.div2.form.gdList.body.gridrow_0.cell_0_0"]'))
-            )
+            from modules.sales_analysis.navigate_to_mid_category import navigate_to_mid_category_sales
+            navigate_to_mid_category_sales(driver)
         elif action == "click":
             driver.find_element("xpath", step["target_xpath"]).click()
         elif action == "sleep":

--- a/modules/sales_analysis/navigate_to_mid_category.py
+++ b/modules/sales_analysis/navigate_to_mid_category.py
@@ -1,0 +1,25 @@
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+import time
+
+
+def navigate_to_mid_category_sales(driver):
+    """Navigate to the '중분류별 매출 구성' page under sales analysis."""
+    print("🟡 매출분석 메뉴 클릭")
+    driver.find_element(By.XPATH, '//*[@id="mainframe.HFrameSet00.VFrameSet00.TopFrame.form.div_topMenu.form.STMB000_M0:icontext"]/div').click()
+    time.sleep(1)
+
+    print("🟡 중분류 메뉴 등장 대기")
+    WebDriverWait(driver, 5).until(
+        EC.presence_of_element_located((By.XPATH, '//*[@id="mainframe.HFrameSet00.VFrameSet00.TopFrame.form.pdiv_topMenu_STMB000_M0.form.STMB011_M0:text"]'))
+    )
+    time.sleep(0.5)
+
+    print("🟢 중분류별 매출 구성비 클릭")
+    driver.find_element(By.XPATH, '//*[@id="mainframe.HFrameSet00.VFrameSet00.TopFrame.form.pdiv_topMenu_STMB000_M0.form.STMB011_M0:text"]').click()
+    time.sleep(2)
+
+    WebDriverWait(driver, 5).until(
+        EC.presence_of_element_located((By.XPATH, '//*[@id="mainframe.HFrameSet00.VFrameSet00.FrameSet.STMB011_M0.form.div_workForm.form.div2.form.gdList.body.gridrow_0.cell_0_0"]'))
+    )


### PR DESCRIPTION
## Summary
- factor out mid category navigation logic into `modules/sales_analysis/navigate_to_mid_category.py`
- call the new helper in `run_sales_analysis` and drop unused imports

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f2033f13c8320ae78537468955c41