### PR TITLE
Add looping mid-category sales automation

### DIFF
--- a/loop_all_categories.py
+++ b/loop_all_categories.py
@@ -1,0 +1,31 @@
+from selenium import webdriver
+from login_runner import run_login
+
+from modules.sales_analysis.navigate_to_mid_category import navigate_to_mid_category_sales
+from modules.sales_analysis.process_one_category import process_one_category
+
+
+def main(start: int = 0, end: int = 900) -> None:
+    """Run automation across mid-category rows."""
+    options = webdriver.ChromeOptions()
+    options.add_argument("--disable-gpu")
+    options.add_argument("--window-size=1920,1080")
+    options.add_argument("--no-sandbox")
+    options.add_argument("--remote-debugging-port=9222")
+    options.set_capability("goog:loggingPrefs", {"performance": "ALL"})
+
+    driver = webdriver.Chrome(options=options)
+    run_login(driver)
+    navigate_to_mid_category_sales(driver)
+
+    for idx in range(start, end + 1):
+        if not process_one_category(driver, idx):
+            print(f"❌ 루프 중단 @ {idx:03d}")
+            break
+
+    input("⏸ Press Enter to exit.")
+    driver.quit()
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/sales_analysis/process_one_category.py
+++ b/modules/sales_analysis/process_one_category.py
@@ -1,0 +1,51 @@
+from selenium.webdriver.common.by import By
+import time
+
+from ssv_listener import extract_ssv_from_cdp
+from parse_and_save import parse_ssv, save_filtered_rows
+from pathlib import Path
+
+
+CATEGORY_CELL = (
+    "//*[@id='mainframe.HFrameSet00.VFrameSet00.FrameSet.STMB011_M0.form.div_workForm.form.div2.form.gdList.body.gridrow_{i}.cell_0_0']"
+)
+
+
+def process_one_category(driver, index: int) -> bool:
+    """Handle one mid-category row.
+
+    Parameters
+    ----------
+    driver : selenium.webdriver
+        Active Selenium driver.
+    index : int
+        Row index for the mid-category grid (0-based).
+
+    Returns
+    -------
+    bool
+        True on success, False if any step failed.
+    """
+    code = f"{index:03d}"
+    try:
+        print(f"🟡 중분류 {code} 클릭")
+        xpath = CATEGORY_CELL.format(i=index)
+        driver.find_element(By.XPATH, xpath).click()
+        time.sleep(0.3)
+        driver.find_element(By.XPATH, xpath + ":text").click()
+        time.sleep(1.5)
+
+        ssv_path = f"output/category_{code}_detail.txt"
+        extract_ssv_from_cdp(driver, keyword="selDetailSearch", save_to=ssv_path)
+        if not Path(ssv_path).exists():
+            raise FileNotFoundError(ssv_path)
+
+        with open(ssv_path, "r", encoding="utf-8") as f:
+            rows = parse_ssv(f.read())
+        out_path = f"output/category_{code}_filtered.txt"
+        save_filtered_rows(rows, out_path, filter_dict={"STOCK_QTY": "0"})
+        print(f"✅ 중분류 {code} 처리 완료")
+        return True
+    except Exception as e:
+        print(f"❌ 중분류 {code} 처리 실패: {e}")
+        return False


### PR DESCRIPTION
## Summary
- implement `process_one_category` helper to click a mid-category row and save filtered data
- add `loop_all_categories.py` to execute the full workflow across mid-categories

## Testing
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f2468c9c48320ab09026a72d28156