### PR TITLE
Add debug messages for process_one_category

### DIFF
--- a/modules/sales_analysis/process_one_category.py
+++ b/modules/sales_analysis/process_one_category.py
@@ -28,6 +28,7 @@ def process_one_category(driver, index: int) -> bool:
     """
     code = f"{index:03d}"
     try:
+        print(f"▶ 중분류 {code} 처리 시작")
         print(f"🟡 중분류 {code} 클릭")
         xpath = CATEGORY_CELL.format(i=index)
         driver.find_element(By.XPATH, xpath).click()
@@ -44,8 +45,8 @@ def process_one_category(driver, index: int) -> bool:
             rows = parse_ssv(f.read())
         out_path = f"output/category_{code}_filtered.txt"
         save_filtered_rows(rows, out_path, filter_dict={"STOCK_QTY": "0"})
-        print(f"✅ 중분류 {code} 처리 완료")
+        print(f"✅ 중분류 {code} 처리 성공")
         return True
     except Exception as e:
-        print(f"❌ 중분류 {code} 처리 실패: {e}")
+        print(f"❌ 중분류 {code} 처리 중 예외 발생: {e}")
         return False


### PR DESCRIPTION
## Summary
- add start message when processing a category
- update success/failure logs to clarify outcome

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f32d8cfe4832096c648c2c39ad242