### PR TITLE
Fix mid-category navigation XPath

### DIFF
--- a/modules/sales_analysis/loop_all_categories.py
+++ b/modules/sales_analysis/loop_all_categories.py
@@ -26,7 +26,7 @@ def main() -> None:
     index = 0
     while True:
         xpath = (
-            f"//*[@id='mainframe.HFrameSet00.VFrameSet00.FrameSet.STMB011_M0.form.div_workForm.form.div2.form.gdList.body.gridrow_{index}.cell_0_0']"
+            f"//*[@id='mainframe.HFrameSet00.VFrameSet00.FrameSet.STMB011_M0.form.WorkFrame.form.grd_msg.body.gridrow_{index}.cell_{index}_0']"
         )
         print(f"🔍 {index:03d}번 row 검사 중...")
         try:

--- a/modules/sales_analysis/navigate_to_mid_category.py
+++ b/modules/sales_analysis/navigate_to_mid_category.py
@@ -21,5 +21,5 @@ def navigate_to_mid_category_sales(driver):
     time.sleep(2)
 
     WebDriverWait(driver, 5).until(
-        EC.presence_of_element_located((By.XPATH, '//*[@id="mainframe.HFrameSet00.VFrameSet00.FrameSet.STMB011_M0.form.div_workForm.form.div2.form.gdList.body.gridrow_0.cell_0_0"]'))
+        EC.presence_of_element_located((By.XPATH, '//*[@id="mainframe.HFrameSet00.VFrameSet00.FrameSet.STMB011_M0.form.WorkFrame.form.grd_msg.body.gridrow_0.cell_0_0"]'))
     )


### PR DESCRIPTION
## Summary
- fix XPath used when looping through mid-category rows
- update navigate helper to wait for the correct grid element

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f3ed247ac83208989b978bb7cf72e