### PR TITLE
Fix log shadowing in sales analysis

### DIFF
--- a/log_util.py
+++ b/log_util.py
@@ -1,0 +1,11 @@
+import logging
+
+
+def create_logger(module_name: str):
+    """Return a step-based logger function for the given module."""
+    logger = logging.getLogger(module_name)
+
+    def log(step: str, msg: str) -> None:
+        logger.info(f"[{module_name} > {step}] {msg}")
+
+    return log

--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 from modules.common.login import run_login
 from modules.common.driver import create_chrome_driver
 from modules.common.module_map import write_module_map
+from log_util import create_logger
 import json
 import time
 import logging
@@ -8,15 +9,13 @@ import logging
 MODULE_NAME = "main"
 
 
-def log(step: str, msg: str) -> None:
-    logger.info(f"[{MODULE_NAME} > {step}] {msg}")
-
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s [%(levelname)s] %(message)s",
     datefmt="%H:%M:%S",
 )
 logger = logging.getLogger(__name__)
+log = create_logger(MODULE_NAME)
 
 
 def run_sales_analysis(driver):
@@ -35,7 +34,7 @@ def run_sales_analysis(driver):
 
     for step in behavior:
         action = step.get("action")
-        log = step.get("log")
+        step_log = step.get("log")
         log("step_start", f"{action} 시작")
         
         if action == "navigate_menu":
@@ -59,8 +58,8 @@ def run_sales_analysis(driver):
                 filter_dict=step.get("filter"),
             )
         log("step_end", f"{action} 완료")
-        if log:
-            log("message", log)
+        if step_log:
+            log("message", step_log)
 
 
 def main():


### PR DESCRIPTION
## Summary
- add a `log_util` helper to supply module-specific loggers
- integrate `create_logger` in `main.py`
- avoid variable name conflict when running sales analysis

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f5a5699388320bc7883b8e1efedc5