### PR TITLE
Add wait-click logic to category loop

### DIFF
--- a/modules/sales_analysis/click_code_001_and_wait.json
+++ b/modules/sales_analysis/click_code_001_and_wait.json
@@ -1,0 +1,27 @@
+{
+  "module": "sales_analysis",
+  "action": "click_code_001_and_wait",
+  "description": "중분류별 매출 구성비 > 코드 001 셀 클릭 후 상세 항목 로딩 대기",
+  "steps": [
+    {
+      "type": "wait",
+      "target": "//*[@id='mainframe.HFrameSet00.VFrameSet00.FrameSet.STMB011_M0.form.div_workForm.form.div2.form.gdList.body.gridrow_0.cell_0_0:text']",
+      "condition": "presence",
+      "timeout": 10,
+      "note": "코드 001 셀의 텍스트 감지를 통해 화면이 준비되었는지 확인"
+    },
+    {
+      "type": "click",
+      "target": "//*[@id='mainframe.HFrameSet00.VFrameSet00.FrameSet.STMB011_M0.form.div_workForm.form.div2.form.gdList.body.gridrow_0.cell_0_0']",
+      "method": "javascript",
+      "note": "코드 001 셀 물리 클릭 (텍스트 요소가 아닌 기능 요소)"
+    },
+    {
+      "type": "wait",
+      "target": "//*[@id='mainframe.HFrameSet00.VFrameSet00.FrameSet.STMB011_M0.form.div_workForm.form.div2.form.gdListSub.body.gridrow_0.cell_0_0']",
+      "condition": "presence",
+      "timeout": 10,
+      "note": "상세 항목의 첫 셀이 로딩될 때까지 대기"
+    }
+  ]
+}

--- a/modules/sales_analysis/loop_all_categories.py
+++ b/modules/sales_analysis/loop_all_categories.py
@@ -17,6 +17,29 @@ def log(step: str, msg: str) -> None:
     print(f"\u25b6 [{MODULE_NAME} > {step}] {msg}")
 
 
+def click_row_and_wait_detail(driver, index: int) -> None:
+    """Click the given row using JavaScript and wait for detail grid to load."""
+
+    row_xpath = (
+        f"//*[@id='mainframe.HFrameSet00.VFrameSet00.FrameSet.STMB011_M0.form.div_workForm.form.div2.form.gdList.body.gridrow_{index}.cell_0_0']"
+    )
+    detail_xpath = (
+        "//*[@id='mainframe.HFrameSet00.VFrameSet00.FrameSet.STMB011_M0.form.div_workForm.form.div2.form.gdListSub.body.gridrow_0.cell_0_0']"
+    )
+
+    log("wait_row", f"gridrow_{index} 등장 대기")
+    WebDriverWait(driver, 10).until(
+        EC.presence_of_element_located((By.XPATH, row_xpath))
+    )
+    element = driver.find_element(By.XPATH, row_xpath)
+    log("click_row", f"gridrow_{index} 클릭")
+    driver.execute_script("arguments[0].click();", element)
+    log("wait_detail", "상세 로딩 대기")
+    WebDriverWait(driver, 10).until(
+        EC.presence_of_element_located((By.XPATH, detail_xpath))
+    )
+
+
 def main() -> None:
     """Run automation across mid-category rows based on visible gridrows."""
     driver = create_chrome_driver()
@@ -39,7 +62,8 @@ def main() -> None:
             break
 
         try:
-            success = process_one_category(driver, index)
+            click_row_and_wait_detail(driver, index)
+            success = process_one_category(driver, index, already_clicked=True)
             if not success:
                 log("row_fail", f"중분류 {index:03d} 처리 실패 — 다음 항목으로 계속")
         except Exception as e:

--- a/modules/sales_analysis/process_one_category.py
+++ b/modules/sales_analysis/process_one_category.py
@@ -18,18 +18,19 @@ CATEGORY_CELL = (
 TEXT_SUFFIX = ":text"  # 텍스트 요소 ID에 사용될 suffix
 
 
-def process_one_category(driver, index: int) -> bool:
-    """Handle one mid-category row with click + separate text extraction."""
+def process_one_category(driver, index: int, already_clicked: bool = False) -> bool:
+    """Handle one mid-category row with optional click and data extraction."""
 
     code = f"{index:03d}"
     try:
         log("start", f"중분류 {code} 처리 시작")
         xpath = CATEGORY_CELL.format(i=index)
 
-        # ✅ 실제 클릭은 기능 요소에서 수행
-        log("click_row", f"중분류 {code} 클릭")
-        driver.find_element(By.XPATH, xpath).click()
-        time.sleep(0.3)
+        if not already_clicked:
+            # ✅ 실제 클릭은 기능 요소에서 수행
+            log("click_row", f"중분류 {code} 클릭")
+            driver.find_element(By.XPATH, xpath).click()
+            time.sleep(0.3)
 
         # ✅ 텍스트 추출은 별도
         try:


### PR DESCRIPTION
## Summary
- integrate waiting steps for detail view into `loop_all_categories`
- allow `process_one_category` to skip its own click when row already clicked

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685f646e44448320b8cd43c470583d74