### PR TITLE
Add popup closing util

### DIFF
--- a/modules/common/popup_utils.py
+++ b/modules/common/popup_utils.py
@@ -1,0 +1,54 @@
+"""Utilities for closing pop-up windows during automation."""
+
+
+POPUP_CLOSE_SCRIPT = """
+(function() {
+  let closed = 0;
+  // Case A: explicit structure containing STCM230_P1
+  const popupAList = Array.from(document.querySelectorAll('[id*="STCM230_P1"]'));
+  popupAList.forEach(popup => {
+    const closeBtn = popup.querySelector('[id$="btnClose"]');
+    if (closeBtn) {
+      closeBtn.click();
+      closed++;
+    }
+  });
+
+  // Case B: generic pattern based structure
+  const popupBList = Array.from(document.querySelectorAll('div')).filter(div => {
+    const style = window.getComputedStyle(div);
+    const isVisible = style.display !== 'none' && style.visibility !== 'hidden' && style.opacity !== '0';
+    const isCentered = style.position === 'fixed' || style.position === 'absolute';
+    const isLarge = div.offsetWidth > 300 && div.offsetHeight > 200;
+    return isVisible && isCentered && isLarge;
+  });
+
+  popupBList.forEach(div => {
+    const closeBtn = div.querySelector('button, div, a');
+    if (closeBtn && /닫기|확인/.test(closeBtn.innerText)) {
+      closeBtn.click();
+      closed++;
+    }
+  });
+
+  return closed;
+})();
+"""
+
+
+def close_popups(driver):
+    """Execute JavaScript in ``driver`` to close known pop-ups.
+
+    Parameters
+    ----------
+    driver : selenium.webdriver.remote.webdriver.WebDriver
+        Active WebDriver instance.
+
+    Returns
+    -------
+    Any
+        Result returned from ``driver.execute_script``, typically the number of
+        pop-ups closed.
+    """
+
+    return driver.execute_script(POPUP_CLOSE_SCRIPT)

--- a/tests/test_popup_utils.py
+++ b/tests/test_popup_utils.py
@@ -1,0 +1,20 @@
+import sys
+from pathlib import Path
+from unittest.mock import Mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from modules.common.popup_utils import close_popups, POPUP_CLOSE_SCRIPT
+
+
+class DummyDriver:
+    def __init__(self):
+        self.execute_script = Mock(return_value=0)
+
+
+def test_close_popups_executes_script():
+    driver = DummyDriver()
+    result = close_popups(driver)
+    driver.execute_script.assert_called_once_with(POPUP_CLOSE_SCRIPT)
+    assert result == 0
+


### PR DESCRIPTION
## Summary
- add new `close_popups` utility that executes JS to close pop-up windows
- include tests verifying the script is executed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f745b3640832097c9d71289f9f928