### PR TITLE
Fix POPUP_CLOSE_SCRIPT to return IIFE

### DIFF
--- a/modules/common/popup_utils.py
+++ b/modules/common/popup_utils.py
@@ -2,7 +2,7 @@
 
 
 POPUP_CLOSE_SCRIPT = """
-(function() {
+return (function() {
   let closed = 0;
   // Case A: explicit structure containing STCM230_P1
   const popupAList = Array.from(document.querySelectorAll('[id*="STCM230_P1"]'));


### PR DESCRIPTION
## Summary
- wrap the JavaScript popup closing script in an explicit `return`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f7c1cad708320b9a77e479ec1d3db