### PR TITLE
Add popup debug logging

### DIFF
--- a/modules/common/popup_utils.py
+++ b/modules/common/popup_utils.py
@@ -4,13 +4,17 @@
 POPUP_CLOSE_SCRIPT = """
 return (function() {
   let closed = 0;
+  let closedIds = [];
+
   // Case A: explicit structure containing STCM230_P1
   const popupAList = Array.from(document.querySelectorAll('[id*="STCM230_P1"]'));
   popupAList.forEach(popup => {
     const closeBtn = popup.querySelector('[id$="btnClose"]');
     if (closeBtn) {
+      console.log('닫기 대상:', closeBtn.innerText, closeBtn.id, closeBtn.className);
       closeBtn.click();
       closed++;
+      closedIds.push(closeBtn.id || '[no-id]');
     }
   });
 
@@ -26,29 +30,21 @@ return (function() {
   popupBList.forEach(div => {
     const closeBtn = div.querySelector('button, div, a');
     if (closeBtn && /닫기|확인/.test(closeBtn.innerText)) {
+      console.log('닫기 대상:', closeBtn.innerText, closeBtn.id, closeBtn.className);
       closeBtn.click();
       closed++;
+      closedIds.push(closeBtn.innerText + ' / ' + (closeBtn.id || '[no-id]'));
     }
   });
 
-  return closed;
+  return { count: closed, targets: closedIds };
 })();
 """
 
 
 def close_popups(driver):
-    """Execute JavaScript in ``driver`` to close known pop-ups.
+    """Execute JavaScript in ``driver`` to close known pop-ups and log results."""
 
-    Parameters
-    ----------
-    driver : selenium.webdriver.remote.webdriver.WebDriver
-        Active WebDriver instance.
-
-    Returns
-    -------
-    Any
-        Result returned from ``driver.execute_script``, typically the number of
-        pop-ups closed.
-    """
-
-    return driver.execute_script(POPUP_CLOSE_SCRIPT)
+    result = driver.execute_script(POPUP_CLOSE_SCRIPT)
+    print("닫기 시도 대상:", result)
+    return result.get("count", 0)

--- a/tests/test_popup_utils.py
+++ b/tests/test_popup_utils.py
@@ -9,7 +9,7 @@ from modules.common.popup_utils import close_popups, POPUP_CLOSE_SCRIPT
 
 class DummyDriver:
     def __init__(self):
-        self.execute_script = Mock(return_value=0)
+        self.execute_script = Mock(return_value={"count": 0, "targets": []})
 
 
 def test_close_popups_executes_script():


### PR DESCRIPTION
## Summary
- enhance JavaScript popup close script with detailed logging
- log closed popup info in Python helper
- update tests for new return data structure

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685f7d7a06ec8320a833f15c0ac63659