### PR TITLE
Improve deduplication in popup closure

### DIFF
--- a/modules/common/popup_utils.py
+++ b/modules/common/popup_utils.py
@@ -4,26 +4,35 @@
 POPUP_CLOSE_SCRIPT = """
 return (function () {
   let closed = 0;
-  let closedIds = new Set();
+  const clickedKeys = new Set();
+  const closedIds = [];
 
   const allCloseCandidates = [];
 
-  // \ub9d0\uae30\uc801 \uad6c\uc870 A
+  // \ub9d0\uae30\uc801 \uad6c\uc870
   const popupAList = Array.from(document.querySelectorAll('[id*="STCM230_P1"]'));
   popupAList.forEach(popup => {
     const closeBtn = popup.querySelector('[id$="btnClose"]');
     if (closeBtn) {
-      allCloseCandidates.push(closeBtn);
+      const key = closeBtn.id || closeBtn.outerHTML.slice(0, 100);
+      if (!clickedKeys.has(key)) {
+        allCloseCandidates.push(closeBtn);
+        clickedKeys.add(key);
+      }
     }
   });
 
-  // \uc77c\ubc18 \uad6c\uc870 B
+  // \uc77c\ubc18 \uad6c\uc870
   const popupBList = Array.from(document.querySelectorAll('div')).filter(div => {
     const style = window.getComputedStyle(div);
-    const isVisible = style.display !== 'none' && style.visibility !== 'hidden' && style.opacity !== '0';
-    const isCentered = style.position === 'fixed' || style.position === 'absolute';
-    const isLarge = div.offsetWidth > 300 && div.offsetHeight > 200;
-    return isVisible && isCentered && isLarge;
+    return (
+      style.display !== 'none' &&
+      style.visibility !== 'hidden' &&
+      style.opacity !== '0' &&
+      (style.position === 'fixed' || style.position === 'absolute') &&
+      div.offsetWidth > 300 &&
+      div.offsetHeight > 200
+    );
   });
 
   popupBList.forEach(div => {
@@ -35,31 +44,32 @@ return (function () {
         btn.getAttribute('role') === 'button' ||
         /btn|nexabutton/.test(btn.className);
 
-      const btnId = btn.id || btn.getAttribute('name') || btn.outerHTML.slice(0, 60);
+      const key = btn.id || btn.outerHTML.slice(0, 100);
       if (
         isClickable &&
         /(\ub2eb\uae30|\ud655\uc778|\ub2e4\uc2dc \ubcf4\uc9c0 \uc54a\uae30)/.test(txt) &&
-        !closedIds.has(btnId)
+        !clickedKeys.has(key)
       ) {
         allCloseCandidates.push(btn);
-        closedIds.add(btnId);
+        clickedKeys.add(key);
       }
     });
   });
-
-  const results = [];
 
   allCloseCandidates.forEach(btn => {
     try {
       btn.click();
       closed++;
-      results.push(`${btn.innerText} / ${btn.id || '[no-id]'}`);
+      closedIds.push(`${btn.innerText || '[no-text]'} / ${btn.id || '[no-id]'}`);
     } catch (e) {
-      results.push(`[\uc2e4\ud328] ${btn.innerText} / ${btn.id || '[no-id]'}`);
+      closedIds.push(`[\uc2e4\ud328] ${btn.innerText || '[no-text]'} / ${btn.id || '[no-id]'}`);
     }
   });
 
-  return { count: closed, targets: results };
+  return {
+    count: closed,
+    targets: closedIds
+  };
 })();
 """
 


### PR DESCRIPTION
## Summary
- implement better duplicate detection in `POPUP_CLOSE_SCRIPT`
- use serialized element keys to avoid clicking the same element twice

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f95ac0c50832084288ea4f21be647