### PR TITLE
Add debug logging for popup detection

### DIFF
--- a/main.py
+++ b/main.py
@@ -111,6 +111,10 @@ def main():
         # ✅ 팝업 자동 닫기
         try:
             popup_result = close_popups(driver)
+            print(
+                "팝업 디버그 정보:",
+                json.dumps(popup_result.get("debug", []), indent=2, ensure_ascii=False),
+            )
             if popup_result.get("detected"):
                 log("popup_detected", "블러 기반 팝업 감지")
                 if popup_result.get("closed"):

--- a/modules/common/popup_utils.py
+++ b/modules/common/popup_utils.py
@@ -7,16 +7,30 @@ return (function () {
     detected: false,
     closed: false,
     reason: "",
-    target: null
+    target: null,
+    debug: []
   };
 
   // 1. \ud31d\uc5c5 \ud3ec\ud568 \uac10\uc9c0 (z-index+fixed+\ud06c\uae30)
-  const allDivs = Array.from(document.querySelectorAll('div'));
+  const allDivs = Array.from(document.querySelectorAll('*'));
+  allDivs.forEach(div => {
+    const style = window.getComputedStyle(div);
+    result.debug.push({
+      id: div.id,
+      z: style.zIndex,
+      pos: style.position,
+      w: div.offsetWidth,
+      h: div.offsetHeight,
+      vis: style.visibility,
+      disp: style.display
+    });
+  });
+
   const popupCandidates = allDivs.filter(div => {
     const style = window.getComputedStyle(div);
     return (
       style.position === 'fixed' &&
-      parseInt(style.zIndex || '0') > 1000 &&
+      parseInt(style.zIndex || '0') > 500 &&
       div.offsetWidth > 300 &&
       div.offsetHeight > 200 &&
       style.display !== 'none' &&


### PR DESCRIPTION
## Summary
- log every element's style info when scanning for popups
- relax the z-index requirement for popup candidates
- print popup debug info from Python

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685fa79b73088320b7c7ed77476037b5