### PR TITLE
Add navigate_menu step to loop_mid_categories

### DIFF
--- a/modules/sales_analysis/loop_mid_categories.json
+++ b/modules/sales_analysis/loop_mid_categories.json
@@ -7,6 +7,9 @@
     "until_missing_xpath": "//*[@id='mainframe.HFrameSet00.VFrameSet00.FrameSet.STMB011_M0.form.div_workForm.form.div2.form.gdList.body.gridrow_${i}.cell_0_0']",
     "steps": [
       {
+        "action": "navigate_menu"
+      },
+      {
         "action": "click",
         "target_xpath": "//*[@id='mainframe.HFrameSet00.VFrameSet00.FrameSet.STMB011_M0.form.div_workForm.form.div2.form.gdList.body.gridrow_${i}.cell_0_0']",
         "method": "javascript"


### PR DESCRIPTION
## Summary
- enable moving to the menu for mid-category analysis loops

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ffb3248c48320bf670ecbf1bc3284