### PR TITLE
Fix loop termination order

### DIFF
--- a/main.py
+++ b/main.py
@@ -83,14 +83,15 @@ def run_sales_analysis(driver, config_path="modules/sales_analysis/loop_mid_cate
         i = loop.get("start", 0)
         while True:
             variables[index_var] = i
+            for step in loop["steps"]:
+                execute_step(step, variables)
+            i += 1
+            variables[index_var] = i
             check_xpath = substitute(loop["until_missing_xpath"], variables)
             try:
                 driver.find_element(By.XPATH, check_xpath)
             except Exception:
                 break
-            for step in loop["steps"]:
-                execute_step(step, variables)
-            i += 1
     else:
         for step in config.get("behavior", []):
             execute_step(step, variables)


### PR DESCRIPTION
## Summary
- change the order of operations inside the loop in `run_sales_analysis`
- the menu navigation step in sales analysis config is already present

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686005f6ef148320883aa95da1367c8c