### PR TITLE
Implement ordered gridrow click loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ This project opens the BGF Retail store login page using Selenium. It is a simpl
    close them automatically.
 
 The mid-category sales automation is now executed directly from `main.py` using
-`modules/sales_analysis/gridrow_click_loop.json`. The JSON first navigates to
-the 중분류별 매출 구성 페이지 and then waits for each mid-category row to
-appear, clicks its code cell, and continues until no further rows are present.
+`modules/sales_analysis/gridrow_click_loop.json`. The JSON navigates to the
+중분류별 매출 구성 페이지 and then runs a helper function that clicks available
+mid-category codes in numerical order.
 
 
 The structure files in the `structure` directory describe the XPath selectors

--- a/main.py
+++ b/main.py
@@ -26,7 +26,10 @@ def run_sales_analysis(driver, config_path="modules/sales_analysis/gridrow_click
     """Execute sales analysis steps defined in a JSON config, supporting loops."""
     from modules.common.network import extract_ssv_from_cdp
     from modules.common.login import load_env
-    from modules.sales_analysis.navigate_to_mid_category import navigate_to_mid_category_sales
+    from modules.sales_analysis.navigate_to_mid_category import (
+        navigate_to_mid_category_sales,
+        click_codes_in_order,
+    )
     from modules.data_parser.parse_and_save import parse_ssv, save_filtered_rows
 
     def substitute(value: str, variables: dict) -> str:
@@ -66,6 +69,10 @@ def run_sales_analysis(driver, config_path="modules/sales_analysis/gridrow_click
                 fields=step.get("fields"),
                 filter_dict=step.get("filter"),
             )
+        elif action == "click_codes_in_order":
+            start = step.get("start", 1)
+            end = step.get("end", 900)
+            click_codes_in_order(driver, start=start, end=end)
         log("step_end", f"{action} 완료")
         if step_log:
             log("message", step_log)

--- a/modules/sales_analysis/gridrow_click_loop.json
+++ b/modules/sales_analysis/gridrow_click_loop.json
@@ -36,27 +36,11 @@
       "target_xpath": "//*[@id='mainframe.HFrameSet00.VFrameSet00.FrameSet.STMB011_M0.form.WorkFrame.form.grd_msg.body.gridrow_0.cell_0_0']",
       "condition": "presence",
       "timeout": 10
+    },
+    {
+      "action": "click_codes_in_order",
+      "start": 1,
+      "end": 900
     }
-  ],
-  "loop": {
-    "index_var": "i",
-    "start": 1,
-    "until_missing_xpath": "//*[contains(@id, 'gridrow_${i}')]",
-    "steps": [
-      {
-        "action": "wait",
-        "target_xpath": "//*[contains(@id, 'gridrow_${i}')]",
-        "condition": "presence",
-        "timeout": 5
-      },
-      {
-        "action": "click",
-        "target_xpath": "//*[contains(@id, 'gridrow_${i}.cell_0_0')]"
-      },
-      {
-        "action": "sleep",
-        "seconds": 0.2
-      }
-    ]
-  }
+  ]
 }

--- a/modules/sales_analysis/navigate_to_mid_category.py
+++ b/modules/sales_analysis/navigate_to_mid_category.py
@@ -29,3 +29,48 @@ def navigate_to_mid_category_sales(driver):
     WebDriverWait(driver, 10).until(
         EC.presence_of_element_located((By.XPATH, '//*[@id="mainframe.HFrameSet00.VFrameSet00.FrameSet.STMB011_M0.form.WorkFrame.form.grd_msg.body.gridrow_0.cell_0_0"]'))
     )
+
+
+def click_codes_in_order(driver, start: int = 1, end: int = 900) -> None:
+    """Click mid-category grid rows in numerical order from ``start`` to ``end``.
+
+    Parameters
+    ----------
+    driver:
+        Selenium WebDriver instance currently on the mid-category sales page.
+    start:
+        Starting code number to attempt clicking. Defaults to ``1``.
+    end:
+        Ending code number to attempt clicking. Defaults to ``900``.
+    """
+
+    from selenium.webdriver.support.ui import WebDriverWait
+    from selenium.webdriver.support import expected_conditions as EC
+    from selenium.webdriver.common.by import By
+
+    code_map = {}
+    gridrows = driver.find_elements(By.XPATH, "//div[contains(@id, 'grdList.body.gridrow')]")
+
+    for row in gridrows:
+        try:
+            cell = row.find_element(By.XPATH, ".//div[contains(@id, 'cell_0_0.text')]")
+            code = cell.text.strip()
+            if code.isdigit():
+                num = int(code)
+                if start <= num <= end:
+                    code_map[num] = cell
+        except Exception as e:
+            print(f"[스킵] 행에서 코드 셀 탐색 실패: {e}")
+            continue
+
+    for num in range(start, end + 1):
+        cell = code_map.get(num)
+        if cell:
+            try:
+                print(f"▶ 코드 {num:03d} 클릭 중...")
+                WebDriverWait(driver, 5).until(EC.element_to_be_clickable(cell)).click()
+                time.sleep(1.0)
+            except Exception as e:
+                print(f"[오류] 코드 {num:03d} 클릭 실패: {e}")
+        else:
+            print(f"[건너뜀] 코드 {num:03d} 없음")


### PR DESCRIPTION
## Summary
- add helper `click_codes_in_order` for ordered row clicks
- support new `click_codes_in_order` action in `run_sales_analysis`
- replace JSON loop with new action invocation
- update mid-category navigation README docs

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686028d8f9f083208bc6454506b99148