### PR TITLE
Fix mid-category cell xpath and logging

### DIFF
--- a/modules/sales_analysis/navigate_to_mid_category.py
+++ b/modules/sales_analysis/navigate_to_mid_category.py
@@ -50,15 +50,16 @@ def click_codes_in_order(driver, start: int = 1, end: int = 900) -> None:
 
     code_map = {}
     gridrows = driver.find_elements(By.XPATH, "//div[contains(@id, 'grdList.body.gridrow')]")
+    log("scan_row", "실행", f"총 행 수: {len(gridrows)}")
 
     for row in gridrows:
         try:
             # Nexacro uses `:text` suffix for the inner text element. Searching
             # for `cell_0_0.text` does not match this pattern, so look for any
-            # div whose id includes both `cell_0_0` and `:text`.
+            # div whose id includes `cell_0_0` and ends with `:text`.
             cell = row.find_element(
                 By.XPATH,
-                ".//div[contains(@id, 'cell_0_0') and contains(@id, ':text')]",
+                ".//div[contains(@id, 'cell_0_0') and substring(@id, string-length(@id) - 5) = ':text']",
             )
             code = cell.text.strip()
             log("scan_row", "실행", f"코드 추출값: {code}")


### PR DESCRIPTION
## Summary
- log total row count in `click_codes_in_order`
- search grid text cells with ids ending in `:text`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68609db4208c8320ad912e79089742bf