### PR TITLE
Add row count log and unify popup debug logging

### DIFF
--- a/main.py
+++ b/main.py
@@ -122,9 +122,13 @@ def main():
         # ✅ 팝업 자동 닫기
         try:
             popup_result = close_popups(driver)
-            print(
-                "팝업 디버그 정보:",
-                json.dumps(popup_result.get("debug", []), indent=2, ensure_ascii=False),
+            log(
+                "popup_debug",
+                "실행",
+                "팝업 디버그 정보: "
+                + json.dumps(
+                    popup_result.get("debug", []), indent=2, ensure_ascii=False
+                ),
             )
             if popup_result.get("detected"):
                 log("popup_detected", "실행", "팝업 감지됨")

--- a/tests/test_click_codes.py
+++ b/tests/test_click_codes.py
@@ -35,6 +35,10 @@ def test_click_codes_in_order_clicks_and_logs(caplog):
     assert cell1.click.called
     assert cell2.click.called
 
+    # verify row count log
+    row_log = any("총 행 수: 2" in rec.getMessage() for rec in caplog.records)
+    assert row_log
+
     # verify log message for missing code 2
     msg_found = any('코드 002 없음' in rec.getMessage() for rec in caplog.records)
     assert msg_found


### PR DESCRIPTION
## Summary
- log popup debug information via log_util
- assert row count logged in `click_codes_in_order`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860cb549d4c832097cb3b25d4866702