### PR TITLE
Reduce repetitive missing code logs

### DIFF
--- a/modules/sales_analysis/navigate_to_mid_category.py
+++ b/modules/sales_analysis/navigate_to_mid_category.py
@@ -71,14 +71,21 @@ def click_codes_in_order(driver, start: int = 1, end: int = 900) -> None:
             log("scan_row", "오류", f"행에서 코드 셀 탐색 실패: {e}")
             continue
 
+    click_success = 0
+    not_found_count = 0
+
     for num in range(start, end + 1):
         cell = code_map.get(num)
         if cell:
             try:
                 log("click_code", "실행", f"코드 {num:03d} 클릭 중...")
                 WebDriverWait(driver, 5).until(EC.element_to_be_clickable(cell)).click()
+                click_success += 1
                 time.sleep(1.0)
             except Exception as e:
                 log("click_code", "오류", f"코드 {num:03d} 클릭 실패: {e}")
         else:
-            log("click_code", "실행", f"코드 {num:03d} 없음")
+            not_found_count += 1
+
+    total = end - start + 1
+    log("click_code", "실행", f"전체 {total} 중 클릭 성공 {click_success}건, 없음 {not_found_count}건")

--- a/tests/test_click_codes.py
+++ b/tests/test_click_codes.py
@@ -39,6 +39,8 @@ def test_click_codes_in_order_clicks_and_logs(caplog):
     row_log = any("총 행 수: 2" in rec.getMessage() for rec in caplog.records)
     assert row_log
 
-    # verify log message for missing code 2
-    msg_found = any('코드 002 없음' in rec.getMessage() for rec in caplog.records)
-    assert msg_found
+    # verify summary log message
+    summary_found = any(
+        '전체 3 중 클릭 성공 2건, 없음 1건' in rec.getMessage() for rec in caplog.records
+    )
+    assert summary_found


### PR DESCRIPTION
## Summary
- accumulate missing code count when clicking mid-category codes
- log a single summary at the end rather than messages for each missing code
- update tests for new summary log output

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861124bed58832091151c392dd4f709