### PR TITLE
Fix XPath in click_codes_in_order

### DIFF
--- a/modules/sales_analysis/navigate_to_mid_category.py
+++ b/modules/sales_analysis/navigate_to_mid_category.py
@@ -49,7 +49,7 @@ def click_codes_in_order(driver, start: int = 1, end: int = 900) -> None:
     from selenium.webdriver.common.by import By
 
     code_map = {}
-    gridrows = driver.find_elements(By.XPATH, "//div[contains(@id, 'grdList.body.gridrow')]")
+    gridrows = driver.find_elements(By.XPATH, "//div[contains(@id, 'gdList.body.gridrow')]")
     log("scan_row", "실행", f"총 행 수: {len(gridrows)}")
 
     for row in gridrows:


### PR DESCRIPTION
## Summary
- correct ID typo in grid row search XPath

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68611c87b73883209cce5e679f42ada9