### PR TITLE
Fix row code lookup using ID-based search

### DIFF
--- a/modules/sales_analysis/navigate_to_mid_category.py
+++ b/modules/sales_analysis/navigate_to_mid_category.py
@@ -54,16 +54,13 @@ def click_codes_in_order(driver, start: int = 1, end: int = 900) -> None:
 
     for row in gridrows:
         try:
-            # Nexacro uses `:text` suffix for the inner text element. Searching
-            # for `cell_0_0.text` does not match this pattern, so look for any
-            # div whose id includes `cell_0_0` and ends with `:text`.
-            # ``ends-with`` is only available in Selenium 4+, so we use a
-            # ``substring`` expression that checks the last ``':text'``
-            # characters regardless of ID length.
-            cell = row.find_element(
-                By.XPATH,
-                ".//div[contains(@id, 'cell_0_0') and substring(@id, string-length(@id) - string-length(':text') + 1) = ':text']",
-            )
+            # ``row`` itself does not contain the ``:text`` div holding the
+            # code string. Instead, Nexacro places that element as a sibling
+            # div with an id of ``{row_id}:text``. Retrieve the row id and
+            # combine it with ``:text`` to locate the proper element from the
+            # driver root.
+            row_id = row.get_attribute("id")
+            cell = driver.find_element(By.ID, f"{row_id}:text")
             code = cell.text.strip()
             log("scan_row", "실행", f"코드 추출값: {code}")
             if code.isdigit():

--- a/tests/test_click_codes.py
+++ b/tests/test_click_codes.py
@@ -9,19 +9,28 @@ from modules.sales_analysis.navigate_to_mid_category import click_codes_in_order
 
 
 def test_click_codes_in_order_clicks_and_logs(caplog):
-    # create mock grid rows with codes 1 and 3
+    # create mock grid rows with ids that map to codes 1 and 3
     row1 = MagicMock()
+    row1.get_attribute.return_value = "row1"
     cell1 = MagicMock()
     cell1.text = "1"
-    row1.find_element.return_value = cell1
 
     row2 = MagicMock()
+    row2.get_attribute.return_value = "row2"
     cell2 = MagicMock()
     cell2.text = "3"
-    row2.find_element.return_value = cell2
 
     driver = MagicMock()
     driver.find_elements.return_value = [row1, row2]
+
+    def find_element_side_effect(by, value):
+        if value == "row1:text":
+            return cell1
+        if value == "row2:text":
+            return cell2
+        raise AssertionError(f"Unexpected id lookup: {value}")
+
+    driver.find_element.side_effect = find_element_side_effect
 
     with patch('selenium.webdriver.support.ui.WebDriverWait') as MockWait, \
          patch('selenium.webdriver.support.expected_conditions.element_to_be_clickable') as mock_clickable:


### PR DESCRIPTION
## Summary
- locate mid-category code text using driver-level ID lookup
- update click code unit test for the new search approach

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68611f45f01c8320b5e8e366f36c220e