### PR TITLE
Fix row id lookup for click_codes_in_order

### DIFF
--- a/modules/sales_analysis/navigate_to_mid_category.py
+++ b/modules/sales_analysis/navigate_to_mid_category.py
@@ -56,11 +56,14 @@ def click_codes_in_order(driver, start: int = 1, end: int = 900) -> None:
         try:
             # ``row`` itself does not contain the ``:text`` div holding the
             # code string. Instead, Nexacro places that element as a sibling
-            # div with an id of ``{row_id}:text``. Retrieve the row id and
-            # combine it with ``:text`` to locate the proper element from the
-            # driver root.
+            # div whose id is based on the row id. Ensure the id references a
+            # cell element and append ``:text`` only if not already present.
             row_id = row.get_attribute("id")
-            cell = driver.find_element(By.ID, f"{row_id}:text")
+            if ".cell_" not in row_id:
+                continue
+
+            text_id = row_id if ":text" in row_id else f"{row_id}:text"
+            cell = driver.find_element(By.ID, text_id)
             code = cell.text.strip()
             log("scan_row", "실행", f"코드 추출값: {code}")
             if code.isdigit():

--- a/tests/test_click_codes.py
+++ b/tests/test_click_codes.py
@@ -11,12 +11,12 @@ from modules.sales_analysis.navigate_to_mid_category import click_codes_in_order
 def test_click_codes_in_order_clicks_and_logs(caplog):
     # create mock grid rows with ids that map to codes 1 and 3
     row1 = MagicMock()
-    row1.get_attribute.return_value = "row1"
+    row1.get_attribute.return_value = "row1.cell_0_0"
     cell1 = MagicMock()
     cell1.text = "1"
 
     row2 = MagicMock()
-    row2.get_attribute.return_value = "row2"
+    row2.get_attribute.return_value = "row2.cell_0_0"
     cell2 = MagicMock()
     cell2.text = "3"
 
@@ -24,9 +24,9 @@ def test_click_codes_in_order_clicks_and_logs(caplog):
     driver.find_elements.return_value = [row1, row2]
 
     def find_element_side_effect(by, value):
-        if value == "row1:text":
+        if value == "row1.cell_0_0:text":
             return cell1
-        if value == "row2:text":
+        if value == "row2.cell_0_0:text":
             return cell2
         raise AssertionError(f"Unexpected id lookup: {value}")
 


### PR DESCRIPTION
## Summary
- handle cases where row id already contains `:text`
- ensure only cell rows are considered
- update unit test for new row id logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686121be66548320b05df4a452bd8523