### PR TITLE
Improve click_codes_in_order robustness

### DIFF
--- a/modules/sales_analysis/navigate_to_mid_category.py
+++ b/modules/sales_analysis/navigate_to_mid_category.py
@@ -82,7 +82,20 @@ def click_codes_in_order(driver, start: int = 1, end: int = 900) -> None:
         if cell:
             try:
                 log("click_code", "실행", f"코드 {num:03d} 클릭 중...")
-                WebDriverWait(driver, 5).until(EC.element_to_be_clickable(cell)).click()
+                # ✅ overlay disappears before attempting click
+                WebDriverWait(driver, 5).until_not(
+                    EC.presence_of_element_located((By.ID, "nexacontainer"))
+                )
+
+                try:
+                    WebDriverWait(driver, 5).until(EC.element_to_be_clickable(cell)).click()
+                except Exception:
+                    # ✅ if not clickable, scroll into view and retry
+                    driver.execute_script(
+                        "arguments[0].scrollIntoView({block: 'center'});", cell
+                    )
+                    WebDriverWait(driver, 5).until(EC.element_to_be_clickable(cell)).click()
+
                 click_success += 1
                 time.sleep(1.0)
             except Exception as e:

--- a/tests/test_click_codes.py
+++ b/tests/test_click_codes.py
@@ -35,6 +35,7 @@ def test_click_codes_in_order_clicks_and_logs(caplog):
     with patch('selenium.webdriver.support.ui.WebDriverWait') as MockWait, \
          patch('selenium.webdriver.support.expected_conditions.element_to_be_clickable') as mock_clickable:
         MockWait.return_value.until.side_effect = lambda cond: cond
+        MockWait.return_value.until_not.side_effect = lambda cond: True
         mock_clickable.side_effect = lambda el: el
 
         with caplog.at_level(logging.INFO):


### PR DESCRIPTION
## Summary
- ensure nexacontainer overlay disappears before clicking
- retry clicking after centering the cell when first attempt fails
- adjust tests for new wait call

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861255f17d08320a2d2dd3b665db9f1