### PR TITLE
Implement arrow-based code navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,9 @@ This project opens the BGF Retail store login page using Selenium. It is a simpl
 
 The mid-category sales automation is now executed directly from `main.py` using
 `modules/sales_analysis/gridrow_click_loop.json`. The JSON navigates to the
-중분류별 매출 구성 페이지 and then runs a helper function that clicks available
-mid-category codes in numerical order.
+중분류별 매출 구성 페이지 and then uses an arrow-key based helper that starts
+at code `001` and moves down the grid clicking each code until a duplicate
+appears.
 
 
 The structure files in the `structure` directory describe the XPath selectors

--- a/main.py
+++ b/main.py
@@ -28,7 +28,7 @@ def run_sales_analysis(driver, config_path="modules/sales_analysis/gridrow_click
     from modules.common.login import load_env
     from modules.sales_analysis.navigate_to_mid_category import (
         navigate_to_mid_category_sales,
-        click_codes_in_order,
+        click_codes_by_arrow,
     )
     from modules.data_parser.parse_and_save import parse_ssv, save_filtered_rows
 
@@ -69,10 +69,10 @@ def run_sales_analysis(driver, config_path="modules/sales_analysis/gridrow_click
                 fields=step.get("fields"),
                 filter_dict=step.get("filter"),
             )
-        elif action == "click_codes_in_order":
-            start = step.get("start", 1)
-            end = step.get("end", 900)
-            click_codes_in_order(driver, start=start, end=end)
+        elif action == "click_codes_by_arrow":
+            start = step.get("start", 1)  # kept for backward compatibility
+            _ = start  # unused but reserved
+            click_codes_by_arrow(driver, delay=step.get("delay", 1))
         log("step_end", "완료", f"{action} 완료")
         if step_log:
             log("message", "실행", step_log)

--- a/modules/sales_analysis/gridrow_click_loop.json
+++ b/modules/sales_analysis/gridrow_click_loop.json
@@ -38,9 +38,8 @@
       "timeout": 10
     },
     {
-      "action": "click_codes_in_order",
-      "start": 1,
-      "end": 900
+      "action": "click_codes_by_arrow",
+      "delay": 1
     }
   ]
 }

--- a/modules/sales_analysis/navigate_to_mid_category.py
+++ b/modules/sales_analysis/navigate_to_mid_category.py
@@ -143,41 +143,31 @@ def click_codes_in_order(driver, start: int = 1, end: int = 900) -> None:
 def click_codes_by_arrow(driver, delay: float = 1.0, max_scrolls: int = 1000) -> None:
     """Click mid-category codes using Arrow Down navigation.
 
-    Starting from code ``001``, this function moves the selection down one row at
-    a time using the keyboard. It clicks each numeric code encountered until a
-    previously visited code reappears or ``max_scrolls`` is reached.
-
-    Parameters
-    ----------
-    driver:
-        Selenium WebDriver instance currently on the mid-category sales page.
-    delay:
-        Seconds to wait after each click. Defaults to ``1.0``.
-    max_scrolls:
-        Maximum number of down-arrow key presses before giving up.
+    Workflow
+    --------
+    1. Locate the grid cell containing the text ``001``.
+    2. Click the cell and wait ``delay`` seconds.
+    3. Press the ↓ arrow key to move to the next row.
+    4. Read the active cell's text and check if it was already visited.
+    5. If not visited, click the cell, wait ``delay`` seconds and add the code
+       to ``visited``.
+    6. Stop when a duplicate code appears or ``max_scrolls`` is reached.
+    7. Log the total number of clicked codes.
     """
 
     actions = ActionChains(driver)
     visited = set()
 
-    gridrows = driver.find_elements(By.XPATH, "//div[contains(@id, 'gdList.body.gridrow')]")
-    found = False
-    for row in gridrows:
-        try:
-            row_id = row.get_attribute("id")
-            cell = driver.find_element(By.ID, f"{row_id}:text")
-            code = cell.text.strip()
-            if code == "001":
-                log("click_code", "실행", "코드 001 클릭")
-                cell.click()
-                visited.add("001")
-                time.sleep(delay)
-                found = True
-                break
-        except Exception:
-            continue
-
-    if not found:
+    try:
+        cell = driver.find_element(
+            By.XPATH,
+            "//div[contains(@id,'gdList.body.gridrow') and contains(text(),'001')]"
+        )
+        log("click_code", "실행", "코드 001 클릭")
+        cell.click()
+        visited.add("001")
+        time.sleep(delay)
+    except Exception as e:
         log("click_code", "오류", "코드 001을 찾지 못함")
         return
 

--- a/tests/test_click_codes.py
+++ b/tests/test_click_codes.py
@@ -1,6 +1,7 @@
 import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
+from selenium.webdriver.common.by import By
 import logging
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
@@ -60,18 +61,15 @@ def test_click_codes_in_order_clicks_and_logs(caplog):
 
 
 def test_click_codes_by_arrow_clicks_until_repeat(caplog):
-    row = MagicMock()
-    row.get_attribute.return_value = "row.cell"
     first_cell = MagicMock()
     first_cell.text = "001"
 
     driver = MagicMock()
-    driver.find_elements.return_value = [row]
 
     def find_element_side_effect(by, value):
-        if value == "row.cell:text":
+        if by == By.XPATH:
             return first_cell
-        raise AssertionError(f"Unexpected id lookup: {value}")
+        raise AssertionError(f"Unexpected lookup: {value}")
 
     driver.find_element.side_effect = find_element_side_effect
 
@@ -94,6 +92,7 @@ def test_click_codes_by_arrow_clicks_until_repeat(caplog):
                 self.drv.switch_to.active_element = next(active_iter)
             except StopIteration:
                 pass
+
 
     driver.switch_to.active_element = first_cell
 


### PR DESCRIPTION
## Summary
- switch runtime action to new `click_codes_by_arrow` helper
- update config and documentation for arrow navigation
- revise `click_codes_by_arrow` to search by text and simplify
- adjust tests for updated behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686154cb752c8320af11563b986d145b