### PR TITLE
Add click after arrow navigation

### DIFF
--- a/modules/sales_analysis/navigate_to_mid_category.py
+++ b/modules/sales_analysis/navigate_to_mid_category.py
@@ -177,6 +177,7 @@ def click_codes_by_arrow(driver, delay: float = 1.0, max_scrolls: int = 1000) ->
 
         try:
             active = driver.switch_to.active_element
+            active.click()  # make sure each moved row is actually clicked
             code = active.text.strip()
 
             if not code or not code.isdigit():

--- a/tests/test_click_codes.py
+++ b/tests/test_click_codes.py
@@ -105,7 +105,7 @@ def test_click_codes_by_arrow_clicks_until_repeat(caplog):
     assert first_cell.click.called
     assert active1.click.called
     assert active2.click.called
-    assert not active3.click.called
+    assert active3.click.called
 
     summary_found = any(
         "총 클릭: 3건" in rec.getMessage() for rec in caplog.records


### PR DESCRIPTION
## Summary
- ensure arrow-down navigation triggers a click on the newly active cell
- update unit test to expect clicking the repeated code row

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861ae9861348320b8c560450e81b533