### PR TITLE
Add retry delay to arrow click helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ The mid-category sales automation is now executed directly from `main.py` using
 `modules/sales_analysis/gridrow_click_loop.json`. The JSON navigates to the
 중분류별 매출 구성 페이지 and then uses an arrow-key based helper that starts
 at code `001` and moves down the grid clicking each code until a duplicate
-appears.
+appears. If a click fails, the helper waits two seconds and presses the down
+arrow once more before retrying. A second failure stops the loop.
 
 
 The structure files in the `structure` directory describe the XPath selectors

--- a/tests/test_click_codes.py
+++ b/tests/test_click_codes.py
@@ -99,7 +99,7 @@ def test_click_codes_by_arrow_clicks_until_repeat(caplog):
         "modules.sales_analysis.navigate_to_mid_category.ActionChains",
         DummyActions,
     ), caplog.at_level(logging.INFO):
-        click_codes_by_arrow(driver, delay=0, max_scrolls=5)
+        click_codes_by_arrow(driver, delay=0, max_scrolls=5, retry_delay=0)
 
     assert first_cell.click.called
     assert cell1.click.called
@@ -157,9 +157,9 @@ def test_click_codes_by_arrow_rescroll_on_missing_cell(caplog):
         "modules.sales_analysis.navigate_to_mid_category.ActionChains",
         DummyActions,
     ), caplog.at_level(logging.INFO):
-        click_codes_by_arrow(driver, delay=0, max_scrolls=3)
+        click_codes_by_arrow(driver, delay=0, max_scrolls=3, retry_delay=0)
 
-    assert call_counts["cell1"] == 2
+    assert call_counts["cell1"] == 1
     assert first_cell.click.called
-    assert cell1.click.called
+    assert not cell1.click.called
     assert cell2.click.called


### PR DESCRIPTION
## Summary
- enhance arrow click helper with 2-second retry delay and optional parameter
- document new behavior in README
- update tests for new arrow retry logic

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861bb4ad5c083208d74ec6a09763728