### PR TITLE
Add action-based focus recovery

### DIFF
--- a/modules/sales_analysis/navigate_to_mid_category.py
+++ b/modules/sales_analysis/navigate_to_mid_category.py
@@ -234,10 +234,27 @@ def click_codes_by_arrow(
                             "종료",
                             f"비정상 active_element 감지: {active_id}",
                         )
+                        try:
+                            log(
+                                "click_code",
+                                "시도",
+                                f"포커스 복구: {last_cell_id}",
+                            )
+                            recover_cell = driver.find_element(By.ID, last_cell_id)
+                            actions.move_to_element(recover_cell).click().perform()
+                            time.sleep(1.0)
+                            log(
+                                "click_code",
+                                "완료",
+                                f"포커스 복구 성공: {last_cell_id}",
+                            )
+                        except Exception as rec_err:
+                            log(
+                                "click_code",
+                                "오류",
+                                f"포커스 복구 실패: {rec_err}",
+                            )
                         next_cell = driver.find_element(By.ID, cell_id)
-                        log("click_code", "실행", f"포커스 복구 시도: {cell_id}")
-                        next_cell.click()
-                        log("click_code", "완료", f"포커스 복구 성공: {cell_id}")
                         found_by_id = True
                 except Exception as err:
                     e = err

--- a/tests/test_click_codes.py
+++ b/tests/test_click_codes.py
@@ -90,6 +90,10 @@ def test_click_codes_by_arrow_clicks_until_repeat(caplog):
     class DummyActions:
         def __init__(self, drv):
             self.drv = drv
+        def move_to_element(self, el):
+            return self
+        def click(self, el=None):
+            return self
         def send_keys(self, key):
             return self
         def perform(self):
@@ -152,6 +156,10 @@ def test_click_codes_by_arrow_rescroll_on_missing_cell(caplog):
     class DummyActions:
         def __init__(self, drv):
             pass
+        def move_to_element(self, el):
+            return self
+        def click(self, el=None):
+            return self
 
         def send_keys(self, key):
             return self
@@ -185,6 +193,8 @@ def test_click_codes_by_arrow_focus_recovery(caplog):
 
     driver = MagicMock()
 
+    last_id = first_cell.get_attribute.return_value
+
     def find_element_side_effect(by, value):
         if by == By.XPATH:
             return first_cell
@@ -194,6 +204,8 @@ def test_click_codes_by_arrow_focus_recovery(caplog):
                 if id_calls["cnt"] == 1:
                     raise Exception("not ready")
                 return cell1
+            if value == last_id:
+                return first_cell
         raise AssertionError(f"Unexpected lookup: {value}")
 
     driver.find_element.side_effect = find_element_side_effect
@@ -205,6 +217,10 @@ def test_click_codes_by_arrow_focus_recovery(caplog):
     class DummyActions:
         def __init__(self, drv):
             pass
+        def move_to_element(self, el):
+            return self
+        def click(self, el=None):
+            return self
 
         def send_keys(self, key):
             return self


### PR DESCRIPTION
## Summary
- improve focus recovery in `click_codes_by_arrow`
- expand DummyActions in tests
- update focus recovery test for new logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861d7ab0c608320b9df7357b3a47ba8