### PR TITLE
Fix row index update after focus recovery

### DIFF
--- a/modules/sales_analysis/navigate_to_mid_category.py
+++ b/modules/sales_analysis/navigate_to_mid_category.py
@@ -253,6 +253,8 @@ def click_codes_by_arrow(
                             )
                             # move index forward so we don't repeat the same cell
                             row_idx += 1
+                            cell_id = f"{prefix}{row_idx}.cell_{row_idx}_0:text"
+                            continue
                         except Exception as rec_err:
                             log(
                                 "click_code",

--- a/tests/test_click_codes.py
+++ b/tests/test_click_codes.py
@@ -204,6 +204,8 @@ def test_click_codes_by_arrow_focus_recovery(caplog):
                 if id_calls["cnt"] == 1:
                     raise Exception("not ready")
                 return cell1
+            if value == "prefix.gdList.body.gridrow_2.cell_2_0:text":
+                return cell1
             if value == last_id:
                 return first_cell
         raise AssertionError(f"Unexpected lookup: {value}")


### PR DESCRIPTION
## Summary
- avoid repeated missing cell attempts in `click_codes_by_arrow`
- update focus recovery test to expect next row lookup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861e88468d883209073df4987ff583d