### PR TITLE
Fix infinite row search after focus recovery

### DIFF
--- a/modules/sales_analysis/navigate_to_mid_category.py
+++ b/modules/sales_analysis/navigate_to_mid_category.py
@@ -252,6 +252,7 @@ def click_codes_by_arrow(
                                 f"포커스 복구 성공: {last_cell_id}",
                             )
                             # move index forward so we don't repeat the same cell
+                            # and avoid searching the previous row again
                             row_idx += 1
                             cell_id = f"{prefix}{row_idx}.cell_{row_idx}_0:text"
                             continue


### PR DESCRIPTION
## Summary
- clarify why row index increments after restoring focus

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861ebcebc448320a94a1f947ff8946c