### PR TITLE
Refactor sales navigation module

### DIFF
--- a/docs/browser_environment.md
+++ b/docs/browser_environment.md
@@ -70,7 +70,8 @@ modules/
 │   ├── network.py         # CDP 로그 수집 및 SSV 저장
 │   └── snippet_utils.py   # XPath → 명령 변환 도구
 ├── sales_analysis/
-│   ├── navigate_to_mid_category.py   # 메뉴 이동
+│   ├── navigation.py                 # 메뉴 이동
+│   ├── mid_category_clicker.py       # 중분류 코드 클릭 기능
 │   ├── process_one_category.py       # 단일 항목 처리
 │   └── loop_all_categories.py        # 반복 처리
 ├── data_parser/

--- a/main.py
+++ b/main.py
@@ -26,10 +26,8 @@ def run_sales_analysis(driver, config_path="modules/sales_analysis/gridrow_click
     """Execute sales analysis steps defined in a JSON config, supporting loops."""
     from modules.common.network import extract_ssv_from_cdp
     from modules.common.login import load_env
-    from modules.sales_analysis.navigate_to_mid_category import (
-        navigate_to_mid_category_sales,
-        click_codes_by_arrow,
-    )
+    from modules.sales_analysis.navigation import navigate_to_mid_category_sales
+    from modules.sales_analysis.mid_category_clicker import click_codes_by_arrow
     from modules.data_parser.parse_and_save import parse_ssv, save_filtered_rows
 
     def substitute(value: str, variables: dict) -> str:

--- a/module_map_main.json
+++ b/module_map_main.json
@@ -23,8 +23,12 @@
       "role": "DOM 스니펫 결과를 JSON 명령으로 변환하거나 ID 규칙에 따라 명령을 생성하는 CLI 도구 제공"
     },
     {
-      "module": "modules/sales_analysis/navigate_to_mid_category.py",
+      "module": "modules/sales_analysis/navigation.py",
       "role": "매출분석 메뉴에서 중분류별 매출 구성 페이지까지 이동"
+    },
+    {
+      "module": "modules/sales_analysis/mid_category_clicker.py",
+      "role": "중분류 코드 그리드에서 셀을 순서대로 클릭"
     },
     {
       "module": "modules/data_parser/parse_and_save.py",

--- a/modules/common/module_map.py
+++ b/modules/common/module_map.py
@@ -25,8 +25,12 @@ MODULE_MAP = {
             "role": "DOM 스니펫 결과를 JSON 명령으로 변환하거나 ID 규칙에 따라 명령을 생성하는 CLI 도구 제공",
         },
         {
-            "module": "modules/sales_analysis/navigate_to_mid_category.py",
+            "module": "modules/sales_analysis/navigation.py",
             "role": "매출분석 메뉴에서 중분류별 매출 구성 페이지까지 이동",
+        },
+        {
+            "module": "modules/sales_analysis/mid_category_clicker.py",
+            "role": "중분류 코드 그리드에서 셀을 순서대로 클릭",
         },
         {
             "module": "modules/data_parser/parse_and_save.py",

--- a/modules/sales_analysis/mid_category_clicker.py
+++ b/modules/sales_analysis/mid_category_clicker.py
@@ -6,58 +6,21 @@ from selenium.webdriver.common.keys import Keys
 import time
 from log_util import create_logger
 
-MODULE_NAME = "navigate_mid"
-
+MODULE_NAME = "mid_click"
 
 log = create_logger(MODULE_NAME)
 
 
 def try_or_none(func):
     """Return the result of ``func`` or ``None`` if it raises."""
-
     try:
         return func()
     except Exception:
         return None
 
 
-def navigate_to_mid_category_sales(driver):
-    """Navigate to the '중분류별 매출 구성' page under sales analysis."""
-    log("open_menu", "실행", "매출분석 메뉴 클릭")
-    driver.find_element(By.XPATH, '//*[@id="mainframe.HFrameSet00.VFrameSet00.TopFrame.form.div_topMenu.form.STMB000_M0"]').click()
-    time.sleep(1)
-
-    log("wait_mid_menu", "실행", "중분류 메뉴 등장 대기")
-    WebDriverWait(driver, 10).until(
-        EC.presence_of_element_located((By.XPATH, '//*[@id="mainframe.HFrameSet00.VFrameSet00.TopFrame.form.pdiv_topMenu_STMB000_M0.form.STMB011_M0"]'))
-    )
-    time.sleep(0.5)
-
-    log("click_mid_sales", "실행", "중분류별 매출 구성비 클릭")
-    driver.find_element(By.XPATH, '//*[@id="mainframe.HFrameSet00.VFrameSet00.TopFrame.form.pdiv_topMenu_STMB000_M0.form.STMB011_M0"]').click()
-    time.sleep(2)
-
-    WebDriverWait(driver, 10).until(
-        EC.presence_of_element_located((By.XPATH, '//*[@id="mainframe.HFrameSet00.VFrameSet00.FrameSet.STMB011_M0.form.WorkFrame.form.grd_msg.body.gridrow_0.cell_0_0"]'))
-    )
-
-
 def click_codes_in_order(driver, start: int = 1, end: int = 900) -> None:
-    """Click mid-category grid rows in numerical order from ``start`` to ``end``.
-
-    Parameters
-    ----------
-    driver:
-        Selenium WebDriver instance currently on the mid-category sales page.
-    start:
-        Starting code number to attempt clicking. Defaults to ``1``.
-    end:
-        Ending code number to attempt clicking. Defaults to ``900``.
-    """
-
-    from selenium.webdriver.support.ui import WebDriverWait
-    from selenium.webdriver.support import expected_conditions as EC
-    from selenium.webdriver.common.by import By
+    """Click mid-category grid rows in numerical order from ``start`` to ``end``."""
 
     code_map = {}
     valid_codes = []
@@ -82,11 +45,7 @@ def click_codes_in_order(driver, start: int = 1, end: int = 900) -> None:
             continue  # 무시하고 다음 행으로
 
     if valid_codes:
-        log(
-            "scan_row",
-            "실행",
-            f"유효 코드 {len(valid_codes)}건 추출됨: {', '.join(valid_codes)}",
-        )
+        log("scan_row", "실행", f"유효 코드 {len(valid_codes)}건 추출됨: {', '.join(valid_codes)}")
     else:
         log("scan_row", "실행", "유효 코드 없음")
 
@@ -98,7 +57,6 @@ def click_codes_in_order(driver, start: int = 1, end: int = 900) -> None:
         if cell:
             try:
                 log("click_code", "실행", f"코드 {num:03d} 클릭 중...")
-                # ✅ overlay disappears before attempting click
                 try:
                     overlay = driver.find_element(By.ID, "nexacontainer")
                     if overlay.is_displayed():
@@ -111,15 +69,12 @@ def click_codes_in_order(driver, start: int = 1, end: int = 900) -> None:
                 try:
                     WebDriverWait(driver, 5).until(EC.element_to_be_clickable(cell)).click()
                 except Exception:
-                    # ✅ if not clickable, scroll into view and retry
-                    driver.execute_script(
-                        "arguments[0].scrollIntoView({block: 'center'});", cell
-                    )
+                    driver.execute_script("arguments[0].scrollIntoView({block: 'center'});", cell)
                     WebDriverWait(driver, 5).until(EC.element_to_be_clickable(cell)).click()
 
                 click_success += 1
                 time.sleep(1.0)
-            except Exception as e:
+            except Exception as e:  # pragma: no cover - unexpected selenium errors
                 import traceback
                 import io
 
@@ -127,21 +82,13 @@ def click_codes_in_order(driver, start: int = 1, end: int = 900) -> None:
                 traceback.print_exc(file=tb_io)
                 trace = tb_io.getvalue().strip()
 
-                log(
-                    "click_code",
-                    "디버그",
-                    f"셀 ID: {cell.get_attribute('id')}"
-                )
+                log("click_code", "디버그", f"셀 ID: {cell.get_attribute('id')}")
                 log(
                     "click_code",
                     "디버그",
                     f"셀 표시 여부: {cell.is_displayed()}, 활성 여부: {cell.is_enabled()}"
                 )
-                log(
-                    "click_code",
-                    "오류",
-                    f"코드 {num:03d} 클릭 실패: {repr(e)}\n{trace}"
-                )
+                log("click_code", "오류", f"코드 {num:03d} 클릭 실패: {repr(e)}\n{trace}")
         else:
             not_found_count += 1
 
@@ -156,25 +103,12 @@ def click_codes_by_arrow(
     retry_delay: float = 2.0,
     search_limit: int = 5,
 ) -> None:
-    """Click mid-category codes using Arrow Down navigation.
-
-    Workflow
-    --------
-    1. Locate the grid cell containing the text ``001``.
-    2. Click the cell and wait ``delay`` seconds.
-    3. Press the ↓ arrow key to move to the next row.
-    4. Read the active cell's text and check if it was already visited.
-    5. If not visited, click the cell, wait ``delay`` seconds and add the code
-       to ``visited``.
-    6. Stop when a duplicate code appears or ``max_scrolls`` is reached.
-    7. Log the total number of clicked codes.
-    """
+    """Click mid-category codes using Arrow Down navigation."""
 
     actions = ActionChains(driver)
     code_counts = {}
     last_cell_id = ""
     last_code = ""
-    e = None
     missing_attempts = 0
     visited = set()
     retry_count = 0
@@ -247,50 +181,29 @@ def click_codes_by_arrow(
                             f"비정상 active_element 감지: {active_id}",
                         )
                         try:
-                            log(
-                                "click_code",
-                                "시도",
-                                f"포커스 복구: {last_cell_id}",
-                            )
+                            log("click_code", "시도", f"포커스 복구: {last_cell_id}")
                             focus_retries += 1
                             if focus_retries >= 5:
-                                log(
-                                    "click_code",
-                                    "종료",
-                                    "같은 셀 복구 반복 초과로 종료",
-                                )
+                                log("click_code", "종료", "같은 셀 복구 반복 초과로 종료")
                                 return
                             recover_cell = driver.find_element(By.ID, last_cell_id)
                             actions.move_to_element(recover_cell).click().perform()
                             time.sleep(1.0)
-                            log(
-                                "click_code",
-                                "완료",
-                                f"포커스 복구 성공: {last_cell_id}",
-                            )
-                            # 포커스 복구 성공 후 다음 셀도 명확히 _0:text 로 강제 지정
+                            log("click_code", "완료", f"포커스 복구 성공: {last_cell_id}")
                             row_idx += 1
                             cell_id = f"{prefix}{row_idx}.cell_{row_idx}_0:text"
                             continue
                         except Exception as rec_err:
-                            log(
-                                "click_code",
-                                "오류",
-                                f"포커스 복구 실패: {rec_err}",
-                            )
+                            log("click_code", "오류", f"포커스 복구 실패: {rec_err}")
                         next_cell = driver.find_element(By.ID, cell_id)
                         found_by_id = True
-                except Exception as err:
-                    e = err
+                except Exception:
                     next_cell = None
 
             try:
                 if next_cell is None:
                     raise Exception("cell missing")
-                driver.execute_script(
-                    "arguments[0].scrollIntoView({block: 'center'});",
-                    next_cell,
-                )
+                driver.execute_script("arguments[0].scrollIntoView({block: 'center'});", next_cell)
                 next_cell.click()
                 if not found_by_id:
                     raise Exception("clicked active element")
@@ -331,11 +244,7 @@ def click_codes_by_arrow(
                     if next_cell is None:
                         missing_attempts += 1
                         if missing_attempts >= search_limit:
-                            log(
-                                "click_code",
-                                "종료",
-                                f"예상 셀 탐색 실패 {missing_attempts}회",
-                            )
+                            log("click_code", "종료", f"예상 셀 탐색 실패 {missing_attempts}회")
                             return
                         row_idx += 1
                         cell_id = f"{prefix}{row_idx}.cell_{row_idx}_0:text"
@@ -357,11 +266,7 @@ def click_codes_by_arrow(
         if code in visited:
             retry_count += 1
             if retry_count >= 3:
-                log(
-                    "click_code",
-                    "종료",
-                    f"동일 코드 {code} 3회 시도 → 종료",
-                )
+                log("click_code", "종료", f"동일 코드 {code} 3회 시도 → 종료")
                 break
         else:
             retry_count = 0

--- a/modules/sales_analysis/navigation.py
+++ b/modules/sales_analysis/navigation.py
@@ -1,0 +1,30 @@
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+import time
+from log_util import create_logger
+
+MODULE_NAME = "navigation"
+
+log = create_logger(MODULE_NAME)
+
+
+def navigate_to_mid_category_sales(driver):
+    """Navigate to the '중분류별 매출 구성' page under sales analysis."""
+    log("open_menu", "실행", "매출분석 메뉴 클릭")
+    driver.find_element(By.XPATH, '//*[@id="mainframe.HFrameSet00.VFrameSet00.TopFrame.form.div_topMenu.form.STMB000_M0"]').click()
+    time.sleep(1)
+
+    log("wait_mid_menu", "실행", "중분류 메뉴 등장 대기")
+    WebDriverWait(driver, 10).until(
+        EC.presence_of_element_located((By.XPATH, '//*[@id="mainframe.HFrameSet00.VFrameSet00.TopFrame.form.pdiv_topMenu_STMB000_M0.form.STMB011_M0"]'))
+    )
+    time.sleep(0.5)
+
+    log("click_mid_sales", "실행", "중분류별 매출 구성비 클릭")
+    driver.find_element(By.XPATH, '//*[@id="mainframe.HFrameSet00.VFrameSet00.TopFrame.form.pdiv_topMenu_STMB000_M0.form.STMB011_M0"]').click()
+    time.sleep(2)
+
+    WebDriverWait(driver, 10).until(
+        EC.presence_of_element_located((By.XPATH, '//*[@id="mainframe.HFrameSet00.VFrameSet00.FrameSet.STMB011_M0.form.WorkFrame.form.grd_msg.body.gridrow_0.cell_0_0"]'))
+    )

--- a/tests/test_click_codes.py
+++ b/tests/test_click_codes.py
@@ -6,7 +6,7 @@ import logging
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from modules.sales_analysis.navigate_to_mid_category import (
+from modules.sales_analysis.mid_category_clicker import (
     click_codes_in_order,
     click_codes_by_arrow,
 )
@@ -36,8 +36,8 @@ def test_click_codes_in_order_clicks_and_logs(caplog):
 
     driver.find_element.side_effect = find_element_side_effect
 
-    with patch('selenium.webdriver.support.ui.WebDriverWait') as MockWait, \
-         patch('selenium.webdriver.support.expected_conditions.element_to_be_clickable') as mock_clickable:
+    with patch('modules.sales_analysis.mid_category_clicker.WebDriverWait') as MockWait, \
+         patch('modules.sales_analysis.mid_category_clicker.EC.element_to_be_clickable') as mock_clickable:
         MockWait.return_value.until.side_effect = lambda cond: cond
         MockWait.return_value.until_not.side_effect = lambda cond: True
         mock_clickable.side_effect = lambda el: el
@@ -100,7 +100,7 @@ def test_click_codes_by_arrow_clicks_until_repeat(caplog):
             pass
 
     with patch(
-        "modules.sales_analysis.navigate_to_mid_category.ActionChains",
+        "modules.sales_analysis.mid_category_clicker.ActionChains",
         DummyActions,
     ), caplog.at_level(logging.INFO):
         click_codes_by_arrow(driver, delay=0, max_scrolls=5, retry_delay=0)
@@ -168,7 +168,7 @@ def test_click_codes_by_arrow_rescroll_on_missing_cell(caplog):
             pass
 
     with patch(
-        "modules.sales_analysis.navigate_to_mid_category.ActionChains",
+        "modules.sales_analysis.mid_category_clicker.ActionChains",
         DummyActions,
     ), caplog.at_level(logging.INFO):
         click_codes_by_arrow(driver, delay=0, max_scrolls=3, retry_delay=0)
@@ -231,7 +231,7 @@ def test_click_codes_by_arrow_focus_recovery(caplog):
             pass
 
     with patch(
-        "modules.sales_analysis.navigate_to_mid_category.ActionChains",
+        "modules.sales_analysis.mid_category_clicker.ActionChains",
         DummyActions,
     ), caplog.at_level(logging.INFO):
         click_codes_by_arrow(driver, delay=0, max_scrolls=1, retry_delay=0)


### PR DESCRIPTION
## Summary
- split `navigate_to_mid_category.py` into two modules: `navigation.py` and `mid_category_clicker.py`
- update imports and tests to use new modules
- document new module structure
- update module map JSON definitions

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686206933a988320abde80a515196aff