### PR TITLE
Handle focus after failed mid-category clicks

### DIFF
--- a/modules/sales_analysis/mid_category_clicker.py
+++ b/modules/sales_analysis/mid_category_clicker.py
@@ -222,7 +222,9 @@ def click_codes_by_arrow(
                             "오류",
                             f"셀 클릭 실패 재시도 {retry_attempts}회: {click_err_inner}",
                         )
+                        last_cell_id = cell_id
                         time.sleep(retry_delay)
+                        continue
 
                 if retry_attempts >= MAX_RETRY:
                     log(


### PR DESCRIPTION
## Summary
- keep `last_cell_id` updated when click retries fail in `click_codes_by_arrow`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68620cae92e0832082269d1739488986