### PR TITLE
Use collected grid cells when clicking codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,18 +19,12 @@ This project opens the BGF Retail store login page using Selenium. It is a simpl
 
 The mid-category sales automation is now executed directly from `main.py` using
 `modules/sales_analysis/gridrow_click_loop.json`. The JSON navigates to the
-중분류별 매출 구성 페이지 and then invokes `click_codes_by_arrow` for the
-grid interaction.
+중분류별 매출 구성 페이지 and then collects all code cells in the grid before
+clicking them sequentially.
 
-`click_codes_by_arrow` first locates the cell containing the text `001`,
-clicks it and remembers the cell ID. The helper then moves down the grid using
-the ↓ key while reading and clicking each code. If a cell is not found or the
-click fails, it scrolls the element into view and retries twice. When retries
-still fail, it attempts to recover by re-clicking the last successful cell and
-searching ahead several rows. During recovery the helper explicitly moves the
-row index forward and reselects the next row's `cell_{i}_0:text` element to
-avoid mismatched focus.
-
+During the grid interaction the script scrolls through all rows, collecting
+every visible code cell. Duplicates are removed and the resulting dictionary is
+sorted by code number. Each cell is clicked in order with retries if needed.
 The loop automatically stops when the same code appears three times or when too
 many consecutive cells are missing. Before exit, the function logs the last
 code, the last cell ID, recent click counts and the current focused element to

--- a/main.py
+++ b/main.py
@@ -27,7 +27,7 @@ def run_sales_analysis(driver, config_path="modules/sales_analysis/gridrow_click
     from modules.common.network import extract_ssv_from_cdp
     from modules.common.login import load_env
     from modules.sales_analysis.navigation import navigate_to_mid_category_sales
-    from modules.sales_analysis.mid_category_clicker import click_codes_by_arrow
+    from modules.sales_analysis.mid_category_clicker import collect_all_code_cells
     from modules.data_parser.parse_and_save import parse_ssv, save_filtered_rows
 
     def substitute(value: str, variables: dict) -> str:
@@ -68,9 +68,27 @@ def run_sales_analysis(driver, config_path="modules/sales_analysis/gridrow_click
                 filter_dict=step.get("filter"),
             )
         elif action == "click_codes_by_arrow":
-            start = step.get("start", 1)  # kept for backward compatibility
-            _ = start  # unused but reserved
-            click_codes_by_arrow(driver, delay=step.get("delay", 1))
+            delay = step.get("delay", 1)
+            max_retry = step.get("max_retry", 3)
+            collected = collect_all_code_cells(driver)
+            for num in sorted(collected):
+                cell = collected[num]
+                attempts = 0
+                code_str = f"{num:03d}"
+                while attempts < max_retry:
+                    try:
+                        driver.execute_script(
+                            "arguments[0].scrollIntoView({block: 'center'});",
+                            cell,
+                        )
+                        WebDriverWait(driver, 5).until(EC.element_to_be_clickable(cell)).click()
+                        log("click_code", "실행", f"코드 {code_str} 클릭")
+                        time.sleep(delay)
+                        break
+                    except Exception as e:
+                        attempts += 1
+                        log("click_code", "오류", f"코드 {code_str} 클릭 실패 {attempts}회: {e}")
+                        time.sleep(delay)
         log("step_end", "완료", f"{action} 완료")
         if step_log:
             log("message", "실행", step_log)


### PR DESCRIPTION
## Summary
- collect grid cells via `collect_all_code_cells` in `run_sales_analysis`
- iterate through the collected dictionary and click codes in order
- update README to explain the new approach

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68622d55f848832098b7715fd367fef4