### PR TITLE
Add helper to scroll grid before clicking codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ The loop automatically stops when the same code appears three times or when too
 many consecutive cells are missing. Before exit, the function logs the last
 code, the last cell ID, recent click counts and the current focused element to
 aid debugging.
+The helper ``scroll_to_expand_dom`` moves the trackbar to the bottom of the grid
+so every code cell is loaded before collection begins.
 
 
 The structure files in the `structure` directory describe the XPath selectors

--- a/tests/test_click_codes.py
+++ b/tests/test_click_codes.py
@@ -82,6 +82,7 @@ def test_click_all_codes_after_scroll_clicks_until_repeat(caplog):
     driver.find_elements.return_value = [cell1, cell2, cell3, cell4]
 
     with patch('modules.sales_analysis.mid_category_clicker.collect_all_code_cells', return_value={1: cell1, 2: cell2, 3: cell3, 4: cell4}), \
+         patch('modules.sales_analysis.mid_category_clicker.scroll_to_expand_dom'), \
          patch('modules.sales_analysis.mid_category_clicker.WebDriverWait') as MockWait, \
          patch('modules.sales_analysis.mid_category_clicker.EC.element_to_be_clickable') as mock_clickable, \
          caplog.at_level(logging.INFO):
@@ -122,6 +123,7 @@ def test_click_all_codes_after_scroll_sorts_and_skips(caplog):
     driver.find_elements.return_value = [invalid, cell1, cell2]
 
     with patch('modules.sales_analysis.mid_category_clicker.collect_all_code_cells', return_value={10: cell1, 3: cell2}), \
+         patch('modules.sales_analysis.mid_category_clicker.scroll_to_expand_dom'), \
          patch('modules.sales_analysis.mid_category_clicker.WebDriverWait') as MockWait, \
          patch('modules.sales_analysis.mid_category_clicker.EC.element_to_be_clickable') as mock_clickable, \
          caplog.at_level(logging.INFO):
@@ -148,6 +150,7 @@ def test_click_all_codes_after_scroll_retry_and_stop(caplog):
     driver.find_elements.return_value = [cell1, cell2]
 
     with patch('modules.sales_analysis.mid_category_clicker.collect_all_code_cells', return_value={1: cell1, 2: cell2}), \
+         patch('modules.sales_analysis.mid_category_clicker.scroll_to_expand_dom'), \
          patch('modules.sales_analysis.mid_category_clicker.WebDriverWait') as MockWait, \
          patch('modules.sales_analysis.mid_category_clicker.EC.element_to_be_clickable') as mock_clickable, \
          caplog.at_level(logging.INFO):


### PR DESCRIPTION
## Summary
- add `scroll_to_expand_dom` to load all grid rows
- call scrolling helper from `click_all_codes_after_scroll`
- document helper usage in README
- adjust tests to patch new helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68623825570483208de5e93fb9638bbd