### PR TITLE
Simplify grid row click loop

### DIFF
--- a/main.py
+++ b/main.py
@@ -27,7 +27,7 @@ def run_sales_analysis(driver, config_path="modules/sales_analysis/gridrow_click
     from modules.common.network import extract_ssv_from_cdp
     from modules.common.login import load_env
     from modules.sales_analysis.navigation import navigate_to_mid_category_sales
-    from modules.sales_analysis.mid_category_clicker import click_all_codes_after_scroll
+    from modules.sales_analysis.mid_category_clicker import click_codes_by_arrow
     from modules.data_parser.parse_and_save import parse_ssv, save_filtered_rows
 
     def substitute(value: str, variables: dict) -> str:
@@ -68,7 +68,7 @@ def run_sales_analysis(driver, config_path="modules/sales_analysis/gridrow_click
                 filter_dict=step.get("filter"),
             )
         elif action == "click_codes_by_arrow":
-            click_all_codes_after_scroll(driver)
+            click_codes_by_arrow(driver)
         log("step_end", "완료", f"{action} 완료")
         if step_log:
             log("message", "실행", step_log)

--- a/modules/sales_analysis/mid_category_clicker.py
+++ b/modules/sales_analysis/mid_category_clicker.py
@@ -1,7 +1,4 @@
 from selenium.webdriver.common.by import By
-from selenium.webdriver.support.ui import WebDriverWait
-from selenium.webdriver.support import expected_conditions as EC
-from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.common.keys import Keys
 import time
 from log_util import create_logger
@@ -10,146 +7,16 @@ MODULE_NAME = "mid_click"
 
 log = create_logger(MODULE_NAME)
 
-# XPath for the grid's vertical scrollbar trackbar
-TRACKBAR_XPATH = (
-    "//*[@id='mainframe.HFrameSet00.VFrameSet00.FrameSet.STMB011_M0.form.div_workForm.form.div2.form.gdList.vscrollbar.trackbar']"
-)
-
-
-def scroll_to_expand_dom(driver, scroll_delay: float = 0.2, max_scrolls: int = 200) -> None:
-    """Scroll the grid's trackbar to ensure all code cells are loaded into the DOM."""
-
-    trackbar = driver.find_element(By.XPATH, TRACKBAR_XPATH)
-    actions = ActionChains(driver)
-
-    for _ in range(max_scrolls):
-        actions.click_and_hold(trackbar).move_by_offset(0, 5).release().perform()
-        time.sleep(scroll_delay)
-
-
-def collect_all_code_cells(driver, scroll_delay: float = 0.2, max_scrolls: int = 200):
-    """Return a mapping of code numbers to cell elements by scrolling the grid."""
-
-    trackbar = driver.find_element(By.XPATH, TRACKBAR_XPATH)
-    actions = ActionChains(driver)
-
-    seen_ids = set()
-    collected = {}
-
-    for _ in range(max_scrolls):
-        cells = driver.find_elements(
-            By.XPATH,
-            "//div[contains(@id,'gdList.body.gridrow_') and contains(@id,'cell_') and contains(@id,'_0:text')]",
-        )
-        for cell in cells:
-            cell_id = cell.get_attribute("id")
-            if not cell_id or cell_id in seen_ids:
-                continue
-            seen_ids.add(cell_id)
-            code = cell.text.strip()
-            if code.isdigit():
-                num = int(code)
-                if 1 <= num <= 900:
-                    collected[num] = cell
-
-        actions.click_and_hold(trackbar).move_by_offset(0, 5).release().perform()
-        time.sleep(scroll_delay)
-
-    return collected
-
-
-def try_or_none(func):
-    """Return the result of ``func`` or ``None`` if it raises."""
-    try:
-        return func()
-    except Exception:
-        return None
-
-
-def click_codes_in_order(driver, start: int = 1, end: int = 900) -> None:
-    """Click mid-category grid rows in numerical order from ``start`` to ``end``."""
-
-    code_map = {}
-    valid_codes = []
-
-    gridrows = driver.find_elements(By.XPATH, "//div[contains(@id, 'gdList.body.gridrow')]")
-    log("scan_row", "실행", f"총 행 수: {len(gridrows)}")
-
-    for row in gridrows:
-        try:
-            row_id = row.get_attribute("id")
-            if not row_id:
-                continue
-            cell = driver.find_element(By.ID, f"{row_id}:text")
-            code = cell.text.strip()
-
-            if code.isdigit():
-                num = int(code)
-                if start <= num <= end:
-                    code_map[num] = cell
-                    valid_codes.append(f"{num:03d}")
-        except Exception:
-            continue  # 무시하고 다음 행으로
-
-    if valid_codes:
-        log("scan_row", "실행", f"유효 코드 {len(valid_codes)}건 추출됨: {', '.join(valid_codes)}")
-    else:
-        log("scan_row", "실행", "유효 코드 없음")
-
-    click_success = 0
-    not_found_count = 0
-
-    for num in range(start, end + 1):
-        cell = code_map.get(num)
-        if cell:
-            try:
-                log("click_code", "실행", f"코드 {num:03d} 클릭 중...")
-                try:
-                    overlay = driver.find_element(By.ID, "nexacontainer")
-                    if overlay.is_displayed():
-                        WebDriverWait(driver, 5).until_not(
-                            EC.presence_of_element_located((By.ID, "nexacontainer"))
-                        )
-                except Exception:
-                    pass
-
-                try:
-                    WebDriverWait(driver, 5).until(EC.element_to_be_clickable(cell)).click()
-                except Exception:
-                    driver.execute_script("arguments[0].scrollIntoView({block: 'center'});", cell)
-                    WebDriverWait(driver, 5).until(EC.element_to_be_clickable(cell)).click()
-
-                click_success += 1
-                time.sleep(1.0)
-            except Exception as e:  # pragma: no cover - unexpected selenium errors
-                import traceback
-                import io
-
-                tb_io = io.StringIO()
-                traceback.print_exc(file=tb_io)
-                trace = tb_io.getvalue().strip()
-
-                log("click_code", "디버그", f"셀 ID: {cell.get_attribute('id')}")
-                log(
-                    "click_code",
-                    "디버그",
-                    f"셀 표시 여부: {cell.is_displayed()}, 활성 여부: {cell.is_enabled()}"
-                )
-                log("click_code", "오류", f"코드 {num:03d} 클릭 실패: {repr(e)}\n{trace}")
-        else:
-            not_found_count += 1
-
-    total = end - start + 1
-    log("click_code", "실행", f"전체 {total} 중 클릭 성공 {click_success}건, 없음 {not_found_count}건")
-
 
 def click_codes_by_arrow(
     driver,
     delay: float = 0.5,
     repeat_limit: int = 3,
-    start_cell_id: str = "mainframe.HFrameSet00.VFrameSet00.FrameSet.STMB011_M0.form.div_workForm.form.div2.form.gdList.body.gridrow_0.cell_0_0",
+    start_cell_id: str = (
+        "mainframe.HFrameSet00.VFrameSet00.FrameSet.STMB011_M0.form.div_workForm.form.div2.form.gdList.body.gridrow_0.cell_0_0"
+    ),
 ) -> None:
-    """Click codes by moving the focus with the down arrow key."""
+    """Click each grid row using the down arrow key until the same code repeats."""
 
     first_cell = driver.find_element(By.ID, start_cell_id)
     first_cell.click()
@@ -163,11 +30,13 @@ def click_codes_by_arrow(
     while True:
         focused = driver.switch_to.active_element
         cell_id = focused.get_attribute("id") or ""
-        code = focused.text.strip()
+        if "gdList.body.gridrow" not in cell_id or not cell_id.endswith("_0_0"):
+            time.sleep(delay)
+            continue
 
+        code = focused.text.strip()
         log("click_code", "실행", f"코드 {code} 클릭")
         focused.click()
-
         code_counts[code] = code_counts.get(code, 0) + 1
         last_cell_id = cell_id
 
@@ -195,120 +64,3 @@ def click_codes_by_arrow(
             "코드 누적": code_counts,
         },
     )
-
-
-
-
-
-
-def click_all_codes_after_scroll(driver) -> None:
-    """Scroll the grid to collect all code cells and click them sequentially."""
-    try:
-        scroll_to_expand_dom(driver)
-    except Exception as e:  # pragma: no cover - best effort scrolling
-        log("scroll", "오류", f"스크롤 실패: {e}")
-
-    collected = collect_all_code_cells(driver, max_scrolls=1)
-    entries = sorted(collected.items())
-
-    code_counts = {}
-    last_code = ""
-    last_cell_id = ""
-
-    for num, cell in entries:
-        code_str = f"{num:03d}"
-        success = False
-
-        for _ in range(3):
-            try:
-                driver.execute_script(
-                    "arguments[0].scrollIntoView({block: 'center'});",
-                    cell,
-                )
-                WebDriverWait(driver, 5).until(EC.element_to_be_clickable(cell)).click()
-                success = True
-                break
-            except Exception as e:
-                log("click_code", "오류", f"코드 {code_str} 클릭 실패: {e}")
-                time.sleep(0.5)
-
-        if not success:
-            log("click_code", "종료", f"코드 {code_str} 클릭 실패 → 루프 종료")
-            break
-
-        code_counts[code_str] = code_counts.get(code_str, 0) + 1
-        last_code, last_cell_id = code_str, cell.get_attribute("id")
-
-        log("click_code", "실행", f"코드 {code_str} 클릭")
-        time.sleep(1.0)
-
-        if code_counts[code_str] >= 3:
-            log("click_code", "종료", f"코드 {code_str} 3회 이상 등장 → 종료")
-            break
-
-    log("click_code", "완료", f"총 클릭: {sum(code_counts.values())}건")
-    log(
-        "click_code",
-        "최종 종료",
-        {
-            "마지막 코드": last_code,
-            "마지막 셀 ID": last_cell_id,
-            "코드 누적": code_counts,
-        },
-    )
-
-def click_codes_with_dom_refresh(driver, scroll_offset: int = 50, repeat_limit: int = 3) -> None:
-    """Repeatedly refresh the DOM and click newly loaded code cells."""
-
-    from selenium.common.exceptions import NoSuchElementException
-
-    def get_trackbar():
-        try:
-            return driver.find_element(By.XPATH, TRACKBAR_XPATH)
-        except NoSuchElementException:
-            return None
-
-    code_counts = {}
-    last_code = 0
-
-    while True:
-        collected = collect_all_code_cells(driver, max_scrolls=1)
-        if not collected:
-            log("click_code", "중단", "코드 셀 없음 → 종료")
-            break
-
-        sorted_items = sorted((num, cell) for num, cell in collected.items() if num > last_code)
-
-        for num, cell in sorted_items:
-            code_str = f"{num:03d}"
-            count = code_counts.get(code_str, 0)
-
-            try:
-                driver.execute_script(
-                    "arguments[0].scrollIntoView({block: 'center'});",
-                    cell,
-                )
-                WebDriverWait(driver, 5).until(EC.element_to_be_clickable(cell)).click()
-                code_counts[code_str] = count + 1
-                last_code = num
-                log("click_code", "실행", f"{code_str} 클릭 ({code_counts[code_str]}회)")
-                time.sleep(1.0)
-
-                if code_counts[code_str] >= repeat_limit:
-                    log(
-                        "click_code",
-                        "종료",
-                        f"{code_str} 코드 {repeat_limit}회 클릭 → 종료 조건 충족",
-                    )
-                    return
-            except Exception as e:  # pragma: no cover - best effort clicking
-                log("click_code", "오류", f"{code_str} 클릭 실패: {e}")
-
-        trackbar = get_trackbar()
-        if not trackbar:
-            log("scroll", "종료", "트랙바 없음 → 더 이상 스크롤 불가")
-            break
-
-        actions = ActionChains(driver)
-        actions.click_and_hold(trackbar).move_by_offset(0, scroll_offset).release().perform()
-        time.sleep(0.5)

--- a/tests/test_click_codes.py
+++ b/tests/test_click_codes.py
@@ -1,270 +1,30 @@
 import sys
 from pathlib import Path
-from unittest.mock import MagicMock, patch
-from selenium.webdriver.common.by import By
+from unittest.mock import MagicMock
 from selenium.webdriver.common.keys import Keys
 import logging
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from modules.sales_analysis.mid_category_clicker import (
-    click_codes_in_order,
-    click_all_codes_after_scroll,
-    collect_all_code_cells,
-    click_codes_with_dom_refresh,
-    click_codes_by_arrow,
-)
+from modules.sales_analysis.mid_category_clicker import click_codes_by_arrow
 
-
-def test_click_codes_in_order_clicks_and_logs(caplog):
-    # create mock grid rows with ids that map to codes 1 and 3
-    row1 = MagicMock()
-    row1.get_attribute.return_value = "row1.cell_0_0"
-    cell1 = MagicMock()
-    cell1.text = "1"
-
-    row2 = MagicMock()
-    row2.get_attribute.return_value = "row2.cell_0_0"
-    cell2 = MagicMock()
-    cell2.text = "3"
-
-    driver = MagicMock()
-    driver.find_elements.return_value = [row1, row2]
-
-    def find_element_side_effect(by, value):
-        if value == "row1.cell_0_0:text":
-            return cell1
-        if value == "row2.cell_0_0:text":
-            return cell2
-        raise AssertionError(f"Unexpected id lookup: {value}")
-
-    driver.find_element.side_effect = find_element_side_effect
-
-    with patch('modules.sales_analysis.mid_category_clicker.WebDriverWait') as MockWait, \
-         patch('modules.sales_analysis.mid_category_clicker.EC.element_to_be_clickable') as mock_clickable:
-        MockWait.return_value.until.side_effect = lambda cond: cond
-        MockWait.return_value.until_not.side_effect = lambda cond: True
-        mock_clickable.side_effect = lambda el: el
-
-        with caplog.at_level(logging.INFO):
-            click_codes_in_order(driver, start=1, end=3)
-
-    # verify cells 1 and 3 clicked
-    assert cell1.click.called
-    assert cell2.click.called
-
-    # verify row count log
-    row_log = any("총 행 수: 2" in rec.getMessage() for rec in caplog.records)
-    assert row_log
-
-    # verify summary log message
-    summary_found = any(
-        '전체 3 중 클릭 성공 2건, 없음 1건' in rec.getMessage() for rec in caplog.records
-    )
-    assert summary_found
-
-
-def test_click_all_codes_after_scroll_clicks_until_repeat(caplog):
-    cell1 = MagicMock()
-    cell1.text = "001"
-    cell1.get_attribute.return_value = "id1_0:text"
-
-    cell2 = MagicMock()
-    cell2.text = "002"
-    cell2.get_attribute.return_value = "id2_0:text"
-
-    cell3 = MagicMock()
-    cell3.text = "002"
-    cell3.get_attribute.return_value = "id3_0:text"
-
-    cell4 = MagicMock()
-    cell4.text = "002"
-    cell4.get_attribute.return_value = "id4_0:text"
-
-    driver = MagicMock()
-    driver.find_elements.return_value = [cell1, cell2, cell3, cell4]
-
-    with patch('modules.sales_analysis.mid_category_clicker.collect_all_code_cells', return_value={1: cell1, 2: cell2, 3: cell3, 4: cell4}), \
-         patch('modules.sales_analysis.mid_category_clicker.scroll_to_expand_dom'), \
-         patch('modules.sales_analysis.mid_category_clicker.WebDriverWait') as MockWait, \
-         patch('modules.sales_analysis.mid_category_clicker.EC.element_to_be_clickable') as mock_clickable, \
-         caplog.at_level(logging.INFO):
-        MockWait.return_value.until.side_effect = lambda cond: cond
-        mock_clickable.side_effect = lambda el: el
-
-        click_all_codes_after_scroll(driver)
-
-    assert cell1.click.called
-    assert cell2.click.called
-    assert cell3.click.called
-    assert cell4.click.called
-
-    summary_found = any(
-        "총 클릭: 4건" in rec.getMessage() for rec in caplog.records
-    )
-    assert summary_found
-
-
-def test_click_all_codes_after_scroll_sorts_and_skips(caplog):
-    invalid = MagicMock()
-    invalid.text = "AA"
-    invalid.get_attribute.return_value = "id0_0:text"
-
-    cell1 = MagicMock()
-    cell1.text = "010"
-    cell1.get_attribute.return_value = "id1_0:text"
-
-    cell2 = MagicMock()
-    cell2.text = "003"
-    cell2.get_attribute.return_value = "id2_0:text"
-
-    clicked = []
-    cell1.click.side_effect = lambda: clicked.append("cell1")
-    cell2.click.side_effect = lambda: clicked.append("cell2")
-
-    driver = MagicMock()
-    driver.find_elements.return_value = [invalid, cell1, cell2]
-
-    with patch('modules.sales_analysis.mid_category_clicker.collect_all_code_cells', return_value={10: cell1, 3: cell2}), \
-         patch('modules.sales_analysis.mid_category_clicker.scroll_to_expand_dom'), \
-         patch('modules.sales_analysis.mid_category_clicker.WebDriverWait') as MockWait, \
-         patch('modules.sales_analysis.mid_category_clicker.EC.element_to_be_clickable') as mock_clickable, \
-         caplog.at_level(logging.INFO):
-        MockWait.return_value.until.side_effect = lambda cond: cond
-        mock_clickable.side_effect = lambda el: el
-
-        click_all_codes_after_scroll(driver)
-
-    assert clicked == ["cell2", "cell1"]
-
-
-def test_click_all_codes_after_scroll_retry_and_stop(caplog):
-    cell1 = MagicMock()
-    cell1.text = "001"
-    cell1.get_attribute.return_value = "id1_0:text"
-    cell1.click.side_effect = [Exception("fail"), None]
-
-    cell2 = MagicMock()
-    cell2.text = "002"
-    cell2.get_attribute.return_value = "id2_0:text"
-    cell2.click.side_effect = [Exception("fail"), Exception("fail"), Exception("fail")]
-
-    driver = MagicMock()
-    driver.find_elements.return_value = [cell1, cell2]
-
-    with patch('modules.sales_analysis.mid_category_clicker.collect_all_code_cells', return_value={1: cell1, 2: cell2}), \
-         patch('modules.sales_analysis.mid_category_clicker.scroll_to_expand_dom'), \
-         patch('modules.sales_analysis.mid_category_clicker.WebDriverWait') as MockWait, \
-         patch('modules.sales_analysis.mid_category_clicker.EC.element_to_be_clickable') as mock_clickable, \
-         caplog.at_level(logging.INFO):
-        MockWait.return_value.until.side_effect = lambda cond: cond
-        mock_clickable.side_effect = lambda el: el
-
-        click_all_codes_after_scroll(driver)
-
-    assert cell1.click.call_count == 2
-    assert cell2.click.call_count == 3
-
-
-def test_collect_all_code_cells_deduplicates():
-    trackbar = MagicMock()
-
-    cell1 = MagicMock()
-    cell1.get_attribute.return_value = "row1_0:text"
-    cell1.text = "001"
-
-    cell2 = MagicMock()
-    cell2.get_attribute.return_value = "row2_0:text"
-    cell2.text = "002"
-
-    driver = MagicMock()
-    driver.find_element.return_value = trackbar
-    driver.find_elements.side_effect = [[cell1], [cell1, cell2]]
-
-    actions = MagicMock()
-    actions.click_and_hold.return_value = actions
-    actions.move_by_offset.return_value = actions
-    actions.release.return_value = actions
-
-    with patch(
-        "modules.sales_analysis.mid_category_clicker.ActionChains", return_value=actions
-    ):
-        result = collect_all_code_cells(driver, scroll_delay=0, max_scrolls=2)
-
-    assert list(sorted(result.keys())) == [1, 2]
-
-
-def test_click_codes_with_dom_refresh_scrolls_and_clicks():
-    cell1 = MagicMock()
-    cell1.text = "001"
-    cell1.get_attribute.return_value = "id1_0:text"
-
-    cell2 = MagicMock()
-    cell2.text = "002"
-    cell2.get_attribute.return_value = "id2_0:text"
-
-    trackbar = MagicMock()
-    driver = MagicMock()
-
-    collects = [{1: cell1, 2: cell2}, {1: cell1, 2: cell2}]
-
-    def collect_side_effect(*args, **kwargs):
-        return collects.pop(0)
-
-    from selenium.common.exceptions import NoSuchElementException
-
-    first_call = True
-
-    def find_element_side_effect(by, value):
-        nonlocal first_call
-        if first_call:
-            first_call = False
-            return trackbar
-        raise NoSuchElementException()
-
-    driver.find_element.side_effect = find_element_side_effect
-
-    actions = MagicMock()
-    actions.click_and_hold.return_value = actions
-    actions.move_by_offset.return_value = actions
-    actions.release.return_value = actions
-
-    with patch(
-        "modules.sales_analysis.mid_category_clicker.collect_all_code_cells",
-        side_effect=collect_side_effect,
-    ), patch(
-        "modules.sales_analysis.mid_category_clicker.WebDriverWait"
-    ) as MockWait, patch(
-        "modules.sales_analysis.mid_category_clicker.EC.element_to_be_clickable"
-    ) as mock_clickable, patch(
-        "modules.sales_analysis.mid_category_clicker.ActionChains",
-        return_value=actions,
-    ):
-        MockWait.return_value.until.side_effect = lambda cond: cond
-        mock_clickable.side_effect = lambda el: el
-
-        click_codes_with_dom_refresh(driver, scroll_offset=10)
-
-    assert cell1.click.called
-    assert cell2.click.called
-    actions.move_by_offset.assert_called_with(0, 10)
 
 def test_click_codes_by_arrow_stops_after_repeat(caplog):
     cell1 = MagicMock()
     cell1.text = "001"
-    cell1.get_attribute.return_value = "id1"
+    cell1.get_attribute.return_value = "gdList.body.gridrow_0.cell_0_0"
 
     cell2 = MagicMock()
     cell2.text = "002"
-    cell2.get_attribute.return_value = "id2"
+    cell2.get_attribute.return_value = "gdList.body.gridrow_1.cell_0_0"
 
     cell3 = MagicMock()
     cell3.text = "002"
-    cell3.get_attribute.return_value = "id3"
+    cell3.get_attribute.return_value = "gdList.body.gridrow_2.cell_0_0"
 
     cell4 = MagicMock()
     cell4.text = "002"
-    cell4.get_attribute.return_value = "id4"
+    cell4.get_attribute.return_value = "gdList.body.gridrow_3.cell_0_0"
 
     cells = [cell1, cell2, cell3, cell4]
 


### PR DESCRIPTION
## Summary
- streamline mid-category clicker to a single arrow-key loop
- update main workflow to call this simplified logic
- reduce tests to cover new behaviour only

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862505e002c83209b9f8f88158914e9