### PR TITLE
Add logging after arrow key move

### DIFF
--- a/modules/sales_analysis/mid_category_clicker.py
+++ b/modules/sales_analysis/mid_category_clicker.py
@@ -73,6 +73,8 @@ def click_codes_by_arrow(
         new_focused = driver.switch_to.active_element
         new_cell_id = new_focused.get_attribute("id") or ""
 
+        log("click_code", "위치확인", f"방향키 ↓ 입력 후 포커스된 셀 ID: {new_cell_id}")
+
         if new_cell_id == prev_cell_id:
             log(
                 "click_code",


### PR DESCRIPTION
## Summary
- log the new focused cell's ID after pressing the down arrow in `click_codes_by_arrow`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686314d7956c8320b524cc5d0c77056e