### PR TITLE
Improve grid focus handling

### DIFF
--- a/modules/sales_analysis/mid_category_clicker.py
+++ b/modules/sales_analysis/mid_category_clicker.py
@@ -35,10 +35,18 @@ def click_codes_by_arrow(
     """
 
     first_cell = driver.find_element(By.ID, start_cell_id)
-    first_cell.click()
-    ActionChains(driver).send_keys(Keys.ARROW_DOWN).perform()  # 강제 포커스 전환
-    log("click_code", "디버깅", "초기 셀 클릭 + 방향키 ↓ 입력 완료")
+    log("click_code", "초기포커스", f"초기 셀 찾음: {start_cell_id}")
+
+    ActionChains(driver).move_to_element(first_cell).click().perform()
+    driver.execute_script("arguments[0].focus();", first_cell)  # JS로 명시적 포커스
     time.sleep(1.0)
+
+    focused = driver.switch_to.active_element
+    log(
+        "click_code",
+        "초기포커스확인",
+        f"초기 포커스된 셀 ID: {focused.get_attribute('id')}",
+    )
 
     last_code = ""
     repeat_count = 0

--- a/tests/test_click_codes.py
+++ b/tests/test_click_codes.py
@@ -47,6 +47,17 @@ def test_click_codes_by_arrow_stops_after_repeat(caplog):
     class DummyActions:
         def __init__(self, driver):
             self.driver = driver
+            self.element = None
+
+        def move_to_element(self, element):
+            self.element = element
+            return self
+
+        def click(self, element=None):
+            target = element or self.element
+            if target is not None:
+                target.click()
+            return self
 
         def send_keys(self, key):
             if key == Keys.ARROW_DOWN:


### PR DESCRIPTION
## Summary
- ensure initial grid cell focus using JavaScript for stability
- update test helper `DummyActions` to support `move_to_element` and `click`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68631ab097748320bf099357cb1f831d