### PR TITLE
Add javascript_keydown action

### DIFF
--- a/main.py
+++ b/main.py
@@ -67,6 +67,26 @@ def run_sales_analysis(driver, config_path="modules/sales_analysis/gridrow_click
                 fields=step.get("fields"),
                 filter_dict=step.get("filter"),
             )
+        elif action == "javascript_keydown":
+            target_id = substitute(step["target_id"], variables)
+            key = step.get("key", "ArrowDown")
+            key_code = step.get("keyCode", 40)
+            driver.execute_script(
+                """
+var e = new KeyboardEvent('keydown', {
+    bubbles: true,
+    cancelable: true,
+    key: arguments[1],
+    code: arguments[1],
+    keyCode: arguments[2],
+    which: arguments[2]
+});
+document.getElementById(arguments[0]).dispatchEvent(e);
+""",
+                target_id,
+                key,
+                key_code,
+            )
         elif action == "click_codes_by_arrow":
             click_codes_by_arrow(driver)
         log("step_end", "완료", f"{action} 완료")

--- a/modules/common/login.py
+++ b/modules/common/login.py
@@ -60,6 +60,26 @@ def run_step(driver, step, elements, env):
     elif action == "script":
         code = step["code"]
         driver.execute_script(code, elements[step["target"]])
+    elif action == "javascript_keydown":
+        target_id = step["target_id"]
+        key = step.get("key", "ArrowDown")
+        key_code = step.get("keyCode", 40)
+        driver.execute_script(
+            """
+var e = new KeyboardEvent('keydown', {
+    bubbles: true,
+    cancelable: true,
+    key: arguments[1],
+    code: arguments[1],
+    keyCode: arguments[2],
+    which: arguments[2]
+});
+document.getElementById(arguments[0]).dispatchEvent(e);
+""",
+            target_id,
+            key,
+            key_code,
+        )
     elif action == "sleep":
         time.sleep(step["seconds"])
     elif action == "extract_texts":

--- a/tests/test_javascript_keydown.py
+++ b/tests/test_javascript_keydown.py
@@ -1,0 +1,24 @@
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from modules.common.login import run_step
+
+
+def test_javascript_keydown_executes_script():
+    driver = MagicMock()
+    step = {
+        "action": "javascript_keydown",
+        "target_id": "cell_0",
+        "key": "ArrowDown",
+    }
+    run_step(driver, step, {}, {})
+
+    driver.execute_script.assert_called_once()
+    args, kwargs = driver.execute_script.call_args
+    assert "KeyboardEvent" in args[0]
+    assert args[1] == "cell_0"
+    assert args[2] == "ArrowDown"
+    assert args[3] == 40


### PR DESCRIPTION
## Summary
- support `javascript_keydown` in common step runner
- handle the same action in sales analysis JSON runner
- test new action with mocked driver

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68631d03c3a88320996d90d5fc183279