### PR TITLE
Add grid click logging utility

### DIFF
--- a/modules/sales_analysis/__init__.py
+++ b/modules/sales_analysis/__init__.py
@@ -1,0 +1,1 @@
+from .grid_click_logger import log_detail, scroll_and_click_loop

--- a/modules/sales_analysis/grid_click_logger.py
+++ b/modules/sales_analysis/grid_click_logger.py
@@ -1,0 +1,47 @@
+from datetime import datetime
+import os
+import time
+from selenium.webdriver.common.by import By
+from selenium.common.exceptions import NoSuchElementException
+
+
+def log_detail(message: str, log_path: str = "grid_click_log.txt") -> None:
+    """Append a timestamped message to the given log file and print it."""
+    timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    with open(log_path, "a", encoding="utf-8") as f:
+        f.write(f"{timestamp} {message}\n")
+    print(f"{timestamp} {message}")
+
+
+def scroll_and_click_loop(
+    driver,
+    max_cells: int = 100,
+    log_path: str = "grid_click_log.txt",
+) -> None:
+    """Scroll each grid cell into view and click it sequentially."""
+    if os.path.exists(log_path):
+        os.remove(log_path)
+
+    base_id = (
+        "mainframe.HFrameSet00.VFrameSet00.FrameSet.STMB011_M0.form.div_workForm"
+        ".form.div2.form.gdList.body.gridrow_"
+    )
+    for i in range(max_cells):
+        cell_id = f"{base_id}{i}.cell_0_0"
+        try:
+            cell = driver.find_element(By.ID, cell_id)
+            driver.execute_script(
+                "arguments[0].scrollIntoView({block: 'center'});",
+                cell,
+            )
+            log_detail(f"[{i}] ▶ 셀 스크롤 완료: {cell_id}", log_path)
+            cell_text = cell.text
+            cell.click()
+            log_detail(
+                f"[{i}] ✅ 클릭 완료 - 코드: '{cell_text}', ID: {cell_id}",
+                log_path,
+            )
+            time.sleep(0.2)
+        except NoSuchElementException:
+            log_detail(f"[{i}] ❌ 셀 접근 실패 - ID 없음: {cell_id} → 루프 종료", log_path)
+            break

--- a/tests/test_grid_click_logger.py
+++ b/tests/test_grid_click_logger.py
@@ -1,0 +1,29 @@
+import os
+from unittest.mock import MagicMock
+from pathlib import Path
+from selenium.common.exceptions import NoSuchElementException
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from modules.sales_analysis.grid_click_logger import scroll_and_click_loop
+
+
+def test_scroll_and_click_loop_logs(tmp_path):
+    log_file = tmp_path / "test_log.txt"
+
+    driver = MagicMock()
+    cells = [MagicMock(), MagicMock()]
+    cells[0].text = "001"
+    cells[1].text = "002"
+    driver.find_element.side_effect = [cells[0], cells[1], NoSuchElementException()]
+    driver.execute_script = MagicMock()
+
+    scroll_and_click_loop(driver, max_cells=5, log_path=str(log_file))
+
+    assert cells[0].click.called
+    assert cells[1].click.called
+    with open(log_file, "r", encoding="utf-8") as f:
+        log_contents = f.read()
+    assert "클릭 완료" in log_contents
+    assert "루프 종료" in log_contents


### PR DESCRIPTION
## Summary
- support detailed grid click logging with `scroll_and_click_loop`
- expose utilities from sales_analysis package
- test new logging helper

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863334bf9788320960571640b665413