### PR TITLE
Improve grid focus logging

### DIFF
--- a/modules/sales_analysis/grid_click_logger.py
+++ b/modules/sales_analysis/grid_click_logger.py
@@ -46,6 +46,7 @@ def scroll_and_click_loop(
                 write_log(f"✅ 셀 {idx} 클릭 시도: ID={cell_id}, 텍스트='{text}'")
 
                 cell.click()
+                cell.send_keys("")  # 명시적 포커스 부여
                 time.sleep(0.2)
 
                 action.send_keys(Keys.ARROW_DOWN).perform()

--- a/tests/test_grid_click_logger.py
+++ b/tests/test_grid_click_logger.py
@@ -37,7 +37,9 @@ def test_scroll_and_click_loop_logs(tmp_path):
     scroll_and_click_loop(driver, max_cells=5, log_path=str(log_file))
 
     assert cells[0].click.called
+    assert cells[0].send_keys.called
     assert cells[1].click.called
+    assert cells[1].send_keys.called
     with open(log_file, "r", encoding="utf-8") as f:
         log_contents = f.read()
     assert "클릭 시도" in log_contents


### PR DESCRIPTION
## Summary
- add explicit focus action when clicking grid cells
- check send_keys calls in grid click logger tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68633de5a57083209aefbbac6638f788