### PR TITLE
Add grid click with scroll helper

### DIFF
--- a/modules/sales_analysis/mid_category_clicker.py
+++ b/modules/sales_analysis/mid_category_clicker.py
@@ -272,3 +272,40 @@ def grid_scroll_click_loop(
             if log_enabled:
                 log("grid_scroll", "완료", f"[{i}] 셀 존재 안 함: {cell_id} → 루프 종료")
             break
+
+
+def grid_click_with_scroll(
+    driver,
+    max_rows: int = 100,
+    scroll_xpath: str = "//*[@id='mainframe.HFrameSet00.VFrameSet00.FrameSet.STMB011_M0.form.div_workForm.form.div2.form.gdList.vscrollbar.incbutton:icontext']",
+) -> None:
+    """Click each grid row and press the grid scrollbar button."""
+
+    base_id = (
+        "mainframe.HFrameSet00.VFrameSet00.FrameSet.STMB011_M0.form.div_workForm"
+        ".form.div2.form.gdList.body"
+    )
+
+    for i in range(max_rows):
+        cell_id = f"{base_id}.gridrow_{i}.cell_0_0"
+        try:
+            code_cell = driver.find_element(By.ID, cell_id)
+            code_text = code_cell.text.strip()
+            log(
+                "grid_click",
+                "실행",
+                f"[{i}] 코드 셀 클릭: ID={cell_id}, 텍스트='{code_text}'",
+            )
+            code_cell.click()
+            time.sleep(0.2)
+
+            scroll_btn = driver.find_element(By.XPATH, scroll_xpath)
+            scroll_btn.click()
+            log("grid_click", "실행", f"[{i}] 스크롤 버튼 클릭 완료")
+            time.sleep(0.4)
+
+        except Exception as e:  # pragma: no cover - generic error handling
+            log("grid_click", "오류", f"[{i}] {e}")
+            break
+
+    log("grid_click", "완료", "전체 셀 클릭 및 스크롤 루프 종료")

--- a/tests/test_click_codes.py
+++ b/tests/test_click_codes.py
@@ -151,3 +151,25 @@ def test_grid_scroll_click_loop_basic(caplog):
     assert cells[1].click.called
     assert driver.execute_script.call_count == 2
     assert any("루프 종료" in rec.getMessage() for rec in caplog.records)
+
+
+def test_grid_click_with_scroll_basic(caplog):
+    driver = MagicMock()
+    cell1 = MagicMock()
+    cell2 = MagicMock()
+    scroll_btn = MagicMock()
+    driver.find_element.side_effect = [
+        cell1,
+        scroll_btn,
+        cell2,
+        scroll_btn,
+        Exception("stop"),
+    ]
+
+    with caplog.at_level(logging.INFO):
+        mid_clicker.grid_click_with_scroll(driver, max_rows=5)
+
+    assert cell1.click.called
+    assert cell2.click.called
+    assert scroll_btn.click.call_count == 2
+    assert any("루프 종료" in rec.getMessage() for rec in caplog.records)


### PR DESCRIPTION
## Summary
- extend `mid_category_clicker` with a helper that clicks grid rows and presses the scroll button
- test the new helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686346294b2c8320be218a5f27c23171