### PR TITLE
Modify arrow fallback click criteria

### DIFF
--- a/tests/test_arrow_fallback_scroll.py
+++ b/tests/test_arrow_fallback_scroll.py
@@ -16,9 +16,9 @@ def test_arrow_fallback_scroll_logs(tmp_path):
     next_cell = MagicMock()
     next_cell.text = "002"
 
-    # calls: start_cell, prev_cell focus, current cell
-    driver.find_element.side_effect = [first_cell, first_cell, next_cell]
-    driver.execute_script.side_effect = ["cell_0_0", "cell_0_0", "cell_1_0", "cell_1_0"]
+    # calls: start_cell, text cell
+    driver.find_element.side_effect = [first_cell, next_cell]
+    driver.execute_script.side_effect = ["cell_0_0", "cell_1_0"]
 
     class DummyActions:
         def __init__(self, driver):


### PR DESCRIPTION
## Summary
- use row index to target `:text` element while scrolling
- only click when text value is within `001`~`900`
- update tests for new element lookup logic

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863ae1e784c8320ab90b4e0203dae45