### PR TITLE
Update arrow fallback search

### DIFF
--- a/tests/test_arrow_fallback_scroll.py
+++ b/tests/test_arrow_fallback_scroll.py
@@ -49,4 +49,5 @@ def test_arrow_fallback_scroll_logs(tmp_path):
         contents = f.read()
 
     assert "ArrowDown" in contents
+    assert "찾은 셀 ID" in contents
     assert "완료" in contents


### PR DESCRIPTION
## Summary
- enhance arrow fallback scrolling
- wait 2 seconds after ArrowDown and search for the focused grid cell
- log the found cell ID

## Testing
- `pytest tests/test_arrow_fallback_scroll.py::test_arrow_fallback_scroll_logs -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863c1ca62e083208b875a5903ce75d6