### PR TITLE
Add focus tracker utility

### DIFF
--- a/modules/sales_analysis/focus_tracker.py
+++ b/modules/sales_analysis/focus_tracker.py
@@ -1,0 +1,48 @@
+from selenium.webdriver.remote.webdriver import WebDriver
+
+from .grid_click_logger import log_detail
+
+
+def highlight_active_element(
+    driver: WebDriver,
+    color: str = "red",
+    thickness: str = "2px",
+    log_path: str = "grid_click_log.txt",
+):
+    """Outline the current active element and log its ID.
+
+    Parameters
+    ----------
+    driver : WebDriver
+        Selenium WebDriver instance.
+    color : str, optional
+        Outline color.
+    thickness : str, optional
+        Outline thickness.
+    log_path : str, optional
+        Path of the log file used by :func:`log_detail`.
+
+    Returns
+    -------
+    str | None
+        ID of the active element if found, otherwise ``None``.
+    """
+    try:
+        elem = driver.execute_script("return document.activeElement")
+    except Exception as e:
+        log_detail(f"❌ activeElement 조회 실패: {e}", log_path=log_path)
+        return None
+
+    if not elem:
+        log_detail("⚠ activeElement 없음", log_path=log_path)
+        return None
+
+    style = f"{thickness} solid {color}"
+    try:
+        driver.execute_script("arguments[0].style.outline=arguments[1]", elem, style)
+    except Exception:
+        pass
+
+    elem_id = elem.get_attribute("id")
+    log_detail(f"현재 포커스: {elem_id}", log_path=log_path)
+    return elem_id

--- a/tests/test_focus_tracker.py
+++ b/tests/test_focus_tracker.py
@@ -1,0 +1,28 @@
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from modules.sales_analysis.focus_tracker import highlight_active_element
+
+
+def test_highlight_active_element_logs(tmp_path):
+    log_file = tmp_path / "focus_log.txt"
+    driver = MagicMock()
+    elem = MagicMock()
+    elem.get_attribute.return_value = "cell_0_0"
+    # first execute_script call returns active element
+    # second call sets outline
+    driver.execute_script.side_effect = [elem, None]
+
+    result = highlight_active_element(driver, color="blue", log_path=str(log_file))
+
+    assert result == "cell_0_0"
+    assert driver.execute_script.call_args_list[0][0][0] == "return document.activeElement"
+    assert "style.outline" in driver.execute_script.call_args_list[1][0][0]
+
+    with open(log_file, "r", encoding="utf-8") as f:
+        contents = f.read()
+    assert "현재 포커스" in contents
+    assert "cell_0_0" in contents


### PR DESCRIPTION
## Summary
- add `focus_tracker.py` to log and highlight current active element
- test focus tracking helper
- install dependencies for tests

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863d9641da48320b9b6895eafac5137