### PR TITLE
Add focus after first cell click

### DIFF
--- a/modules/sales_analysis/arrow_fallback_scroll.py
+++ b/modules/sales_analysis/arrow_fallback_scroll.py
@@ -89,6 +89,7 @@ def scroll_with_arrow_fallback_loop(
     try:
         first_cell = driver.find_element(By.ID, start_cell_id)
         ActionChains(driver).move_to_element(first_cell).click().perform()
+        driver.execute_script("arguments[0].focus();", first_cell)
         time.sleep(0.5)
         prev_id = get_active_id()
         write_log(f"• 초기 포커스: {prev_id}")

--- a/tests/test_arrow_fallback_scroll.py
+++ b/tests/test_arrow_fallback_scroll.py
@@ -18,7 +18,7 @@ def test_arrow_fallback_scroll_logs(tmp_path):
 
     # calls: start_cell, text cell
     driver.find_element.side_effect = [first_cell, next_cell]
-    driver.execute_script.side_effect = ["cell_0_0", "cell_1_0"]
+    driver.execute_script.side_effect = [None, "cell_0_0", "cell_1_0"]
 
     class DummyActions:
         def __init__(self, driver):
@@ -51,3 +51,4 @@ def test_arrow_fallback_scroll_logs(tmp_path):
     assert "ArrowDown" in contents
     assert "찾은 셀 ID" in contents
     assert "완료" in contents
+    assert driver.execute_script.call_args_list[0][0][0] == "arguments[0].focus();"


### PR DESCRIPTION
## Summary
- ensure the first grid cell gets focused after click
- test that focus script is called

## Testing
- `pytest -q`
- `pytest tests/test_arrow_fallback_scroll.py::test_arrow_fallback_scroll_logs -q`


------
https://chatgpt.com/codex/tasks/task_e_68645c84c43083209ce7147c3ccb2d7a