### PR TITLE
Add retry logic to arrow scroll

### DIFF
--- a/modules/sales_analysis/arrow_fallback_scroll.py
+++ b/modules/sales_analysis/arrow_fallback_scroll.py
@@ -111,6 +111,22 @@ def scroll_with_arrow_fallback_loop(
 
         write_log(f"[{i}] 찾은 셀 ID → {curr_id}")
 
+        if curr_id == prev_id:
+            action.send_keys(Keys.ARROW_DOWN).perform()
+            write_log(f"[{i}] ↩ 재시도: ↓ ArrowDown")
+            time.sleep(2)
+            cell_elem = find_cell_under_mainframe(driver)
+            if isinstance(cell_elem, str):
+                curr_id = cell_elem
+            elif cell_elem is not None:
+                curr_id = cell_elem.get_attribute("id")
+            else:
+                curr_id = get_active_id()
+            write_log(f"[{i}] 재시도 후 ID → {curr_id}")
+            if curr_id == prev_id:
+                write_log(f"[{i}] ⚠ 이동 실패: {curr_id}")
+                break
+
         if not curr_id:
             write_log(f"[{i}] ⚠ activeElement 없음 → 중단")
             break
@@ -140,6 +156,7 @@ def scroll_with_arrow_fallback_loop(
 
             if text.isdigit() and 1 <= int(text) <= 900:
                 cell.click()
+                driver.execute_script("arguments[0].focus();", cell)
                 write_log(f"[{i}] ✅ 셀 클릭 완료")
             else:
                 write_log(f"[{i}] ⚠ 클릭 건너뜀: 텍스트 '{text}'")

--- a/tests/test_arrow_fallback_scroll.py
+++ b/tests/test_arrow_fallback_scroll.py
@@ -18,7 +18,7 @@ def test_arrow_fallback_scroll_logs(tmp_path):
 
     # calls: start_cell, text cell
     driver.find_element.side_effect = [first_cell, next_cell]
-    driver.execute_script.side_effect = [None, "cell_0_0", "cell_1_0"]
+    driver.execute_script.side_effect = [None, "cell_0_0", "cell_1_0", None]
 
     class DummyActions:
         def __init__(self, driver):
@@ -52,3 +52,47 @@ def test_arrow_fallback_scroll_logs(tmp_path):
     assert "찾은 셀 ID" in contents
     assert "완료" in contents
     assert driver.execute_script.call_args_list[0][0][0] == "arguments[0].focus();"
+
+
+def test_arrow_fallback_scroll_retries_on_no_move(tmp_path):
+    log_file = tmp_path / "retry_log.txt"
+
+    driver = MagicMock()
+    first_cell = MagicMock()
+    first_cell.text = "001"
+
+    # only the initial cell is needed; loop will break before next search
+    driver.find_element.side_effect = [first_cell]
+    driver.execute_script.side_effect = [None, "cell_0_0", "cell_0_0", "cell_0_0"]
+
+    send_calls = []
+
+    class DummyActions:
+        def __init__(self, driver):
+            pass
+
+        def move_to_element(self, element):
+            return self
+
+        def click(self, element=None):
+            return self
+
+        def send_keys(self, *args):
+            send_calls.append(args)
+            return self
+
+        def perform(self):
+            pass
+
+    original_actions = afs.ActionChains
+    afs.ActionChains = DummyActions
+    try:
+        afs.scroll_with_arrow_fallback_loop(driver, max_steps=1, log_path=str(log_file))
+    finally:
+        afs.ActionChains = original_actions
+
+    with open(log_file, "r", encoding="utf-8") as f:
+        contents = f.read()
+
+    assert any("이동 실패" in line for line in contents.splitlines())
+    assert len(send_calls) == 2


### PR DESCRIPTION
## Summary
- retry ArrowDown once if active element doesn't change
- ensure clicked cells keep focus for next iteration
- test ArrowDown fallback retries
- adapt existing test for extra focus call

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68645e07275c83208a3fc315520c1897