### PR TITLE
Improve arrow fallback logging

### DIFF
--- a/modules/sales_analysis/arrow_fallback_scroll.py
+++ b/modules/sales_analysis/arrow_fallback_scroll.py
@@ -140,15 +140,19 @@ def scroll_with_arrow_fallback_loop(
 
     try:
         first_cell = driver.find_element(By.ID, start_cell_id)
+    except Exception as e:
+        write_log(f"❌ 초기 셀 찾기 실패: ID={start_cell_id}, 오류: {e}")
+        return
+    else:
         time.sleep(1)
         ActionChains(driver).move_to_element(first_cell).click().perform()
         driver.execute_script("arguments[0].focus();", first_cell)
         time.sleep(0.5)
         prev_id = get_active_id()
-        write_log(f"• 초기 포커스 및 클릭: {prev_id}")
-    except Exception as e:
-        write_log(f"❌ 초기 셀 포커스 실패: {e}")
-        return
+        loc = first_cell.location
+        write_log(
+            f"• 초기 포커스 및 클릭: {prev_id} (x={loc.get('x')}, y={loc.get('y')})"
+        )
 
     # move once to start from the next row
     action.send_keys(Keys.ARROW_DOWN).perform()


### PR DESCRIPTION
## Summary
- log start-cell coordinates in `scroll_with_arrow_fallback_loop`
- add tests for logging coordinates and error handling
- adjust nested log path test for new error handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864982d5ffc8320b940197c6056490b