### PR TITLE
Add entry point for arrow fallback scroll module

### DIFF
--- a/modules/sales_analysis/arrow_fallback_scroll.py
+++ b/modules/sales_analysis/arrow_fallback_scroll.py
@@ -249,3 +249,12 @@ def scroll_with_arrow_fallback_loop(
         curr_id = next_id
 
     write_log("✅ 완료: 방향키 기반 셀 이동 종료", step="end")
+
+if __name__ == "__main__":
+    from selenium import webdriver
+    driver = webdriver.Chrome()
+    try:
+        navigate_to_mid_category_sales(driver)
+        scroll_with_arrow_fallback_loop(driver)
+    finally:
+        driver.quit()


### PR DESCRIPTION
## Summary
- add a `__main__` guard in `arrow_fallback_scroll.py` to run the scroll loop directly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68649f8cb4208320aa205998e91eb2bd