### PR TITLE
Improve logger to support file output

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,19 @@ This project opens the BGF Retail store login page using Selenium. It is a simpl
    It also detects pop-up dialogs using z-index and size rules and attempts to
    close them automatically.
 
+## Logging
+
+`create_logger` now accepts an optional file path so console messages can also
+be saved to disk. Example:
+
+```python
+from log_util import create_logger
+log = create_logger("arrow_fallback", log_file="arrow_fallback.log")
+```
+
+Detailed steps inside `scroll_with_arrow_fallback_loop` continue to use the
+``log_path`` argument for their own log file.
+
 The mid-category sales automation now relies on the Python functions in
 `modules/sales_analysis`. These helpers navigate the grid and click each cell in
 order while logging progress. Arrow key input is combined with direct clicks to

--- a/log_util.py
+++ b/log_util.py
@@ -1,8 +1,17 @@
 import logging
 
 
-def create_logger(module_name: str):
-    """Return a state-based logger function for the given module."""
+def create_logger(module_name: str, log_file: str | None = None):
+    """Return a state-based logger function for the given module.
+
+    Parameters
+    ----------
+    module_name : str
+        Name used as the logger name.
+    log_file : str, optional
+        If given, the logger also writes messages to this file using the same
+        format as the console output.
+    """
 
     logger = logging.getLogger(module_name)
 
@@ -11,8 +20,19 @@ def create_logger(module_name: str):
         fmt="%(asctime)s [%(levelname)s] %(message)s", datefmt="%H:%M:%S"
     )
     handler.setFormatter(formatter)
-    if not logger.hasHandlers():
+
+    if not any(isinstance(h, logging.StreamHandler) for h in logger.handlers):
         logger.addHandler(handler)
+
+    if log_file and not any(
+        isinstance(h, logging.FileHandler) and h.baseFilename == log_file
+        for h in logger.handlers
+    ):
+        file_handler = logging.FileHandler(log_file, encoding="utf-8")
+        file_handler.setFormatter(formatter)
+        logger.addHandler(file_handler)
+
+    if not logger.level:
         logger.setLevel(logging.INFO)
 
     # Prevent duplicate log lines by stopping propagation to the root logger

--- a/modules/sales_analysis/arrow_fallback_scroll.py
+++ b/modules/sales_analysis/arrow_fallback_scroll.py
@@ -11,7 +11,7 @@ from log_util import create_logger
 from .grid_click_logger import log_detail
 
 MODULE_NAME = "arrow_fallback"
-log = create_logger(MODULE_NAME)
+log = create_logger(MODULE_NAME, log_file=f"{MODULE_NAME}.log")
 
 
 def navigate_to_mid_category_sales(driver):

--- a/tests/test_log_util.py
+++ b/tests/test_log_util.py
@@ -1,0 +1,15 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from log_util import create_logger
+
+
+def test_create_logger_writes_file(tmp_path):
+    log_file = tmp_path / "out.log"
+    log = create_logger("unit", log_file=str(log_file))
+    log("step", "실행", "hello")
+    with open(log_file, "r", encoding="utf-8") as f:
+        contents = f.read()
+    assert "hello" in contents
+


### PR DESCRIPTION
## Summary
- allow specifying a log file when creating a logger
- log arrow_fallback messages to `arrow_fallback.log`
- document logger file option in README
- add unit test for logger file output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864b1ffe1a0832099204adc44cede4d