### PR TITLE
Fix login failure propagation

### DIFF
--- a/main.py
+++ b/main.py
@@ -234,10 +234,10 @@ def main():
 
         # ✅ 매출 분석 메뉴 진입
         navigate_to_mid_category_sales(driver)
-    except Exception as e:
+    except Exception:
         logger.exception(f"[{MODULE_NAME} > login] 로그인 시퀀스 실패")
         driver.quit()
-        raise
+        return
 
     log("sales_analysis", "실행", "매출 분석")
     try:

--- a/modules/common/login.py
+++ b/modules/common/login.py
@@ -161,4 +161,6 @@ def run_login(driver, config_path="login_sequence.json"):
             run_step(driver, step, elements, env)
         except Exception as e:
             log("step_fail", "오류", f"Step 실패: {step.get('action')} → {e}")
-            break
+            raise
+
+    return True

--- a/tests/test_login_failure.py
+++ b/tests/test_login_failure.py
@@ -1,0 +1,27 @@
+import sys
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from modules.common import login as login_module
+
+
+def test_run_login_raises_on_step_failure(tmp_path, monkeypatch):
+    config_file = tmp_path / "conf.json"
+    with open(config_file, "w", encoding="utf-8") as f:
+        json.dump({"steps": [{"action": "dummy"}]}, f)
+
+    driver = MagicMock()
+
+    def fail_step(driver, step, elements, env):
+        raise RuntimeError("fail")
+
+    monkeypatch.setattr(login_module, "run_step", fail_step)
+    monkeypatch.setattr(login_module, "load_env", lambda: {"LOGIN_ID": "id", "LOGIN_PW": "pw"})
+
+    with pytest.raises(RuntimeError):
+        login_module.run_login(driver, config_path=str(config_file))
+


### PR DESCRIPTION
## Summary
- raise exceptions from `run_login` when a step fails
- exit `main` early on login failure
- test login failure handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6864fa04a08483209348931f849e4114