### PR TITLE
Fix mid-category start cell selector

### DIFF
--- a/modules/sales_analysis/arrow_fallback_scroll.py
+++ b/modules/sales_analysis/arrow_fallback_scroll.py
@@ -55,7 +55,7 @@ def navigate_to_mid_category_sales(driver):
             EC.presence_of_element_located(
                 (
                     By.XPATH,
-                    '//*[@id="mainframe.HFrameSet00.VFrameSet00.FrameSet.STMB011_M0.form.WorkFrame.form.grd_msg.body.gridrow_0.cell_0_0"]',
+                    '//*[@id="mainframe.HFrameSet00.VFrameSet00.FrameSet.STMB011_M0.form.div_workForm.form.div2.form.gdList.body.gridrow_0.cell_0_0:text"]',
                 )
             )
         )
@@ -115,7 +115,7 @@ def scroll_with_arrow_fallback_loop(
     driver,
     max_steps: int = 100,
     start_cell_id: str = (
-        "mainframe.HFrameSet00.VFrameSet00.FrameSet.STMB011_M0.form.div_workForm.form.div2.form.gdList.body.gridrow_0.cell_0_0"
+        "mainframe.HFrameSet00.VFrameSet00.FrameSet.STMB011_M0.form.div_workForm.form.div2.form.gdList.body.gridrow_0.cell_0_0:text"
     ),
     log_path: str = "grid_click_log.txt",
     exit_on_repeat: bool = False,

--- a/modules/sales_analysis/mid_category_clicker.py
+++ b/modules/sales_analysis/mid_category_clicker.py
@@ -65,7 +65,7 @@ def click_codes_by_arrow(
     repeat_limit: int = 3,
     focus_retry_limit: int = 5,
     start_cell_id: str = (
-        "mainframe.HFrameSet00.VFrameSet00.FrameSet.STMB011_M0.form.div_workForm.form.div2.form.gdList.body.gridrow_0.cell_0_0"
+        "mainframe.HFrameSet00.VFrameSet00.FrameSet.STMB011_M0.form.div_workForm.form.div2.form.gdList.body.gridrow_0.cell_0_0:text"
     ),
     row_start: int = 0,
     row_end: int | None = None,

--- a/tests/test_arrow_fallback_scroll.py
+++ b/tests/test_arrow_fallback_scroll.py
@@ -22,11 +22,11 @@ def test_arrow_fallback_scroll_logs(tmp_path):
     driver.find_element.side_effect = [first_cell, next_cell, row_elem]
     driver.execute_script.side_effect = [
         None,  # focus first
-        "gridrow_0.cell_0_0",  # initial active id
-        "gridrow_1.cell_1_0",  # after first ArrowDown
-        "gridrow_1.cell_1_0",  # find_cell_under_mainframe
+        "gridrow_0.cell_0_0:text",  # initial active id
+        "gridrow_1.cell_1_0:text",  # after first ArrowDown
+        "gridrow_1.cell_1_0:text",  # find_cell_under_mainframe
         None,  # focus after click
-        "gridrow_2.cell_2_0",  # next cell after ArrowDown
+        "gridrow_2.cell_2_0:text",  # next cell after ArrowDown
     ]
 
     class DummyActions:
@@ -70,7 +70,7 @@ def test_arrow_fallback_scroll_forces_move_after_three_same(tmp_path):
     cell = MagicMock()
     cell.text = "001"
     driver.find_element.return_value = cell
-    driver.execute_script.return_value = "gridrow_0.cell_0_0"
+    driver.execute_script.return_value = "gridrow_0.cell_0_0:text"
 
     send_calls = []
 
@@ -146,7 +146,7 @@ def test_arrow_fallback_scroll_stop_on_repeat(tmp_path):
     cell = MagicMock()
     cell.text = "001"
     driver.find_element.return_value = cell
-    driver.execute_script.return_value = "gridrow_0.cell_0_0"
+    driver.execute_script.return_value = "gridrow_0.cell_0_0:text"
 
     send_calls = []
 
@@ -191,7 +191,7 @@ def test_first_cell_location_logged(tmp_path):
     first_cell.text = "001"
     first_cell.location = {"x": 10, "y": 20}
     driver.find_element.return_value = first_cell
-    driver.execute_script.return_value = "gridrow_0.cell_0_0"
+    driver.execute_script.return_value = "gridrow_0.cell_0_0:text"
 
     class DummyActions:
         def __init__(self, driver):
@@ -236,4 +236,4 @@ def test_start_cell_error_logged(tmp_path):
         contents = f.read()
 
     assert "초기 셀 찾기 실패" in contents
-    assert "gridrow_0.cell_0_0" in contents
+    assert "gridrow_0.cell_0_0:text" in contents

--- a/tests/test_click_codes.py
+++ b/tests/test_click_codes.py
@@ -12,7 +12,7 @@ import modules.sales_analysis.mid_category_clicker as mid_clicker
 def test_click_codes_by_arrow_stops_after_repeat(caplog):
     cell1 = MagicMock()
     cell1.text = "001"
-    cell1.get_attribute.return_value = "gdList.body.gridrow_0.cell_0_0"
+    cell1.get_attribute.return_value = "gdList.body.gridrow_0.cell_0_0:text"
 
     cell2 = MagicMock()
     cell2.text = "002"
@@ -239,7 +239,7 @@ def test_grid_click_with_scroll_from_20_basic(capsys, tmp_path):
     def find_element_side_effect(by, value):
         if by == mid_clicker.By.ID and value.endswith("gdList.body"):
             return grid_elem
-        if by == mid_clicker.By.ID and value.endswith("gridrow_0.cell_0_0"):
+        if by == mid_clicker.By.ID and value.endswith("gridrow_0.cell_0_0:text"):
             return cells[0]
         if by == mid_clicker.By.XPATH:
             find_element_side_effect.calls += 1


### PR DESCRIPTION
## Summary
- update default start cell selector to include `:text`
- wait for gdList grid on page navigation
- adjust tests for new selector

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865a45736c883209704b0557cac500f