### PR TITLE
Add arrow-based grid row click helper

### DIFF
--- a/modules/sales_analysis/row_click_by_arrow.py
+++ b/modules/sales_analysis/row_click_by_arrow.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import re
+import time
+from selenium.webdriver.common.by import By
+from selenium.webdriver.common.action_chains import ActionChains
+from selenium.webdriver.common.keys import Keys
+
+from log_util import create_logger
+
+MODULE_NAME = "row_click_arrow"
+log = create_logger(MODULE_NAME)
+
+
+def row_click_by_arrow(
+    driver,
+    start_cell_id: str,
+    text_suffix: str = ":text",
+    delay: float = 0.5,
+    max_repeat: int = 3,
+    max_steps: int = 100,
+) -> None:
+    """Move down the grid via ArrowDown and click cells matching a numeric text.
+
+    Parameters
+    ----------
+    driver : WebDriver
+        Selenium WebDriver instance.
+    start_cell_id : str
+        ID of the first grid cell to focus before moving.
+    text_suffix : str, optional
+        Suffix used to locate the text element for each row.
+    delay : float, optional
+        Pause between key presses.
+    max_repeat : int, optional
+        Stop when the same cell is focused this many times in a row.
+    max_steps : int, optional
+        Maximum iterations before aborting.
+    """
+
+    base_prefix = start_cell_id.split("gridrow_")[0] + "gridrow_"
+    try:
+        start_cell = driver.find_element(By.ID, start_cell_id)
+        ActionChains(driver).move_to_element(start_cell).click().perform()
+        driver.execute_script("arguments[0].focus();", start_cell)
+    except Exception as e:
+        log("start", "오류", f"초기 셀 클릭 실패: {e}")
+        return
+
+    action = ActionChains(driver)
+    prev_id = None
+    repeat = 0
+
+    for _ in range(max_steps):
+        active = driver.switch_to.active_element
+        cell_id = active.get_attribute("id") or ""
+
+        if cell_id == prev_id:
+            repeat += 1
+            if repeat >= max_repeat:
+                log("loop", "완료", f"동일 셀 {repeat}회 반복 → 종료")
+                break
+        else:
+            repeat = 0
+
+        m = re.search(r"gridrow_(\d+)", cell_id)
+        if not m:
+            action.send_keys(Keys.ARROW_DOWN).perform()
+            time.sleep(delay)
+            prev_id = cell_id
+            continue
+
+        row_idx = m.group(1)
+        text_id = f"{base_prefix}{row_idx}.cell_{row_idx}_0{text_suffix}"
+        try:
+            text_elem = driver.find_element(By.ID, text_id)
+            text = text_elem.text.strip()
+        except Exception:
+            action.send_keys(Keys.ARROW_DOWN).perform()
+            time.sleep(delay)
+            prev_id = cell_id
+            continue
+
+        if text.isdigit() and 1 <= int(text) <= 900:
+            real_cell_id = f"{base_prefix}{row_idx}.cell_{row_idx}_0"
+            try:
+                driver.find_element(By.ID, real_cell_id).click()
+                log("click", "완료", f"{real_cell_id} 클릭")
+            except Exception as e:
+                log("click", "오류", f"{real_cell_id} 클릭 실패: {e}")
+        else:
+            log("skip", "실행", f"조건 불일치: '{text}'")
+
+        action.send_keys(Keys.ARROW_DOWN).perform()
+        time.sleep(delay)
+        prev_id = cell_id
+

--- a/tests/test_row_click_by_arrow.py
+++ b/tests/test_row_click_by_arrow.py
@@ -1,0 +1,96 @@
+from unittest.mock import MagicMock
+import logging
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import modules.sales_analysis.row_click_by_arrow as rca
+
+
+def test_row_click_by_arrow_clicks_numeric():
+    start_cell = MagicMock()
+    start_cell.text = "001"
+    start_cell.get_attribute.return_value = "prefix.gridrow_0.cell_0_0"
+
+    text_cell1 = MagicMock()
+    text_cell1.text = "001"
+    text_cell1.get_attribute.return_value = "ignored"
+    real_cell1 = MagicMock()
+    real_cell1.get_attribute.return_value = "prefix.gridrow_1.cell_1_0"
+
+    text_cell2 = MagicMock()
+    text_cell2.text = "abc"
+    text_cell2.get_attribute.return_value = "ignored"
+    real_cell2 = MagicMock()
+    real_cell2.get_attribute.return_value = "prefix.gridrow_2.cell_2_0"
+
+    # driver.find_element calls in order:
+    # 0 start cell
+    # 1 text cell for row 0
+    # 2 real cell for row 0
+    # 3 text cell for row 1
+    # 4 real cell for row 1
+    driver = MagicMock()
+    driver.find_element.side_effect = [
+        start_cell,
+        text_cell1,
+        real_cell1,
+        text_cell2,
+        real_cell2,
+    ]
+
+    class DummySwitch:
+        def __init__(self, elems):
+            self.elems = elems
+            self.idx = 0
+
+        @property
+        def active_element(self):
+            return self.elems[self.idx]
+
+        def next(self):
+            if self.idx < len(self.elems) - 1:
+                self.idx += 1
+
+    switch = DummySwitch([start_cell, real_cell1, real_cell2])
+    driver.switch_to = switch
+    driver.execute_script = MagicMock()
+
+    moves = []
+
+    class DummyActions:
+        def __init__(self, _driver):
+            pass
+
+        def move_to_element(self, elem):
+            self.elem = elem
+            return self
+
+        def click(self, element=None):
+            (element or self.elem).click()
+            return self
+
+        def send_keys(self, *args):
+            moves.append(args)
+            switch.next()
+            return self
+
+        def perform(self):
+            pass
+
+    original_actions = rca.ActionChains
+    rca.ActionChains = DummyActions
+    try:
+        rca.row_click_by_arrow(
+            driver,
+            start_cell_id="prefix.gridrow_0.cell_0_0",
+            max_steps=2,
+            delay=0,
+        )
+    finally:
+        rca.ActionChains = original_actions
+
+    assert real_cell1.click.called
+    assert not real_cell2.click.called
+    assert len(moves) >= 2


### PR DESCRIPTION
## Summary
- implement `row_click_by_arrow` helper to click rows using ArrowDown
- create tests verifying the helper

## Testing
- `pytest -q tests/test_row_click_by_arrow.py`
- `pytest -q` *(fails: interrupted due to long runtime)*

------
https://chatgpt.com/codex/tasks/task_e_6865b670a3d48320956de3abd48c2a2a