### PR TITLE
Add cell filter logger

### DIFF
--- a/modules/sales_analysis/cell_filter_logger.py
+++ b/modules/sales_analysis/cell_filter_logger.py
@@ -1,0 +1,40 @@
+from selenium.webdriver.common.by import By
+from selenium.common.exceptions import NoSuchElementException
+
+from log_util import create_logger
+
+MODULE_NAME = "cell_filter_logger"
+log = create_logger(MODULE_NAME)
+
+
+def click_cells_log_filter(driver, filter_value: str, max_cells: int = 100) -> None:
+    """Click cells sequentially and log when a cell text matches a filter.
+
+    Parameters
+    ----------
+    driver : WebDriver
+        Selenium WebDriver instance.
+    filter_value : str
+        Text value to search for in each cell.
+    max_cells : int, optional
+        Maximum number of cells to iterate over.
+    """
+    base_id = (
+        "mainframe.HFrameSet00.VFrameSet00.FrameSet.STMB011_M0.form.div_workForm"
+        ".form.div2.form.gdList.body"
+    )
+
+    for idx in range(max_cells):
+        cell_id = f"{base_id}.gridrow_{idx}.cell_{idx}_0"
+        try:
+            cell = driver.find_element(By.ID, cell_id)
+            text = cell.text.strip()
+            if filter_value in text:
+                log("filter", "성공", f"[{idx}] 필터 '{filter_value}' 발견: {text}")
+            else:
+                log("filter", "실행", f"[{idx}] 필터 미일치: {text}")
+            cell.click()
+        except NoSuchElementException:
+            log("click", "완료", f"[{idx}] 셀 미존재 → 종료")
+            break
+

--- a/tests/test_cell_filter_logger.py
+++ b/tests/test_cell_filter_logger.py
@@ -1,0 +1,42 @@
+from unittest.mock import MagicMock
+import logging
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from modules.sales_analysis import cell_filter_logger as cfl
+
+
+def test_click_cells_log_filter_logs_filter(caplog):
+    cells = [MagicMock(), MagicMock(), MagicMock()]
+    cells[0].text = "abc"
+    cells[1].text = "filter"
+    cells[2].text = "xyz"
+
+    for c in cells:
+        c.click = MagicMock()
+
+    side_effects = cells + [Exception("stop")]
+
+    def fake_find(by, value):
+        result = side_effects.pop(0)
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    driver = MagicMock()
+    driver.find_element.side_effect = fake_find
+
+    with caplog.at_level(logging.INFO, logger=cfl.MODULE_NAME):
+        logger = logging.getLogger(cfl.MODULE_NAME)
+        logger.addHandler(caplog.handler)
+        try:
+            cfl.click_cells_log_filter(driver, "filter", max_cells=3)
+        finally:
+            logger.removeHandler(caplog.handler)
+
+    assert cells[0].click.called
+    assert cells[1].click.called
+    assert cells[2].click.called
+    assert any("필터 'filter' 발견" in rec.getMessage() for rec in caplog.records)


### PR DESCRIPTION
## Summary
- add a helper to log which filter value is found while clicking grid cells
- test the new filter logger

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865f64aff948320ae53c7cc5b55904c