### PR TITLE
Add grid cell wait helper

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,6 +9,7 @@ from modules.sales_analysis.arrow_fallback_scroll import (
 )
 from modules.sales_analysis.row_click_by_arrow import row_click_by_arrow
 from modules.sales_analysis.cell_filter_logger import click_cells_log_filter
+from modules.common.wait_utils import wait_and_click_cell
 import importlib
 import json
 import time
@@ -236,9 +237,13 @@ def main():
 
         # ✅ 매출 분석 메뉴 진입
         navigate_to_mid_category_sales(driver)
+        target_cell_id = (
+            "mainframe.HFrameSet00.VFrameSet00.FrameSet.STMB011_M0.form.div_workForm.form.div2.form.gdList.body.gridrow_0.cell_0_0"
+        )
+        wait_and_click_cell(driver, target_cell_id)
         row_click_by_arrow(
             driver,
-            start_cell_id="mainframe.HFrameSet00.VFrameSet00.FrameSet.STMB011_M0.form.div_workForm.form.div2.form.gdList.body.gridrow_0.cell_0_0:text",
+            start_cell_id=target_cell_id,
         )
         click_cells_log_filter(driver, "filter", max_cells=100)
     except Exception:

--- a/modules/common/wait_utils.py
+++ b/modules/common/wait_utils.py
@@ -1,0 +1,26 @@
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+
+
+def wait_and_click_cell(driver, cell_id: str, timeout: int = 10) -> None:
+    """Wait for a grid cell to appear and be clickable, then click it.
+
+    Parameters
+    ----------
+    driver : WebDriver
+        Selenium WebDriver instance.
+    cell_id : str
+        DOM ID of the grid cell to click.
+    timeout : int, optional
+        Maximum seconds to wait for the cell.
+    """
+    WebDriverWait(driver, timeout).until(
+        EC.presence_of_element_located((By.XPATH, f'//*[@id="{cell_id}"]'))
+    )
+    WebDriverWait(driver, timeout).until(
+        EC.element_to_be_clickable((By.ID, cell_id))
+    )
+    driver.find_element(By.ID, cell_id).click()
+
+__all__ = ["wait_and_click_cell"]

--- a/tests/test_wait_utils.py
+++ b/tests/test_wait_utils.py
@@ -1,0 +1,27 @@
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from modules.common.wait_utils import wait_and_click_cell
+from selenium.webdriver.common.by import By
+
+
+def test_wait_and_click_cell_waits_and_clicks():
+    driver = MagicMock()
+    with patch('modules.common.wait_utils.WebDriverWait') as MockWait, patch('modules.common.wait_utils.EC') as MockEC:
+        instance = MockWait.return_value
+        instance.until.side_effect = [None, None]
+        condition_presence = MagicMock()
+        condition_clickable = MagicMock()
+        MockEC.presence_of_element_located.return_value = condition_presence
+        MockEC.element_to_be_clickable.return_value = condition_clickable
+
+        wait_and_click_cell(driver, 'cell', timeout=5)
+
+        MockWait.assert_called_with(driver, 5)
+        instance.until.assert_any_call(condition_presence)
+        instance.until.assert_any_call(condition_clickable)
+    driver.find_element.assert_called_once_with(By.ID, 'cell')
+


### PR DESCRIPTION
## Summary
- add new helper `wait_and_click_cell` to wait for grid cells to be clickable
- integrate the helper in `main.py` and adjust initial cell id
- test the helper with `pytest`

## Testing
- `pytest tests/test_wait_utils.py -q`
- `pytest tests/test_log_util.py tests/test_row_click_by_arrow.py tests/test_arrow_fallback_scroll.py tests/test_wait_utils.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68660d9642c883208269e9c1037a21cf