### PR TITLE
Fix missing selenium import for tests

### DIFF
--- a/modules/common/wait_utils.py
+++ b/modules/common/wait_utils.py
@@ -1,6 +1,13 @@
-from selenium.webdriver.common.by import By
-from selenium.webdriver.support.ui import WebDriverWait
-from selenium.webdriver.support import expected_conditions as EC
+"""Utility helpers for waiting on and clicking grid cells."""
+
+try:  # pragma: no cover - allow tests to run without selenium installed
+    from selenium.webdriver.common.by import By
+    from selenium.webdriver.support.ui import WebDriverWait
+    from selenium.webdriver.support import expected_conditions as EC
+except ModuleNotFoundError:  # pragma: no cover - fallback when selenium missing
+    By = None
+    WebDriverWait = None
+    EC = None
 
 
 def wait_and_click_cell(driver, cell_id: str, timeout: int = 10) -> None:
@@ -15,6 +22,9 @@ def wait_and_click_cell(driver, cell_id: str, timeout: int = 10) -> None:
     timeout : int, optional
         Maximum seconds to wait for the cell.
     """
+    if By is None or WebDriverWait is None or EC is None:
+        raise ImportError("selenium is required for wait_and_click_cell")
+
     WebDriverWait(driver, timeout).until(
         EC.presence_of_element_located((By.XPATH, f'//*[@id="{cell_id}"]'))
     )


### PR DESCRIPTION
## Summary
- handle missing selenium in wait_utils by falling back when module not installed
- use `ImportError` guard in `wait_and_click_cell`

## Testing
- `pytest -q tests/test_wait_utils.py`
- `pytest -q` *(fails: KeyboardInterrupt due to long runtime but shows tests passing)*

------
https://chatgpt.com/codex/tasks/task_e_68661ee31790832083de511085864332