### PR TITLE
Add popup handling for Nexacro pages

### DIFF
--- a/bgf_login_project/login/login_bgf.py
+++ b/bgf_login_project/login/login_bgf.py
@@ -4,6 +4,7 @@ import json
 import time
 
 from utils.log_util import create_logger
+from utils.popup_util import close_nexacro_popups
 
 log = create_logger("login_bgf")
 
@@ -84,6 +85,10 @@ try {
             success = False
         if success:
             log("login", "SUCCESS", "Login succeeded")
+            try:
+                close_nexacro_popups(driver)
+            except Exception as e:
+                log("login", "WARNING", f"Popup close failed: {e}")
             return True
     log("login", "FAIL", "Login check timeout")
     return False

--- a/bgf_login_project/utils/popup_util.py
+++ b/bgf_login_project/utils/popup_util.py
@@ -1,0 +1,46 @@
+from selenium.webdriver.remote.webdriver import WebDriver
+
+from .log_util import create_logger
+
+log = create_logger("popup_util")
+
+
+def close_nexacro_popups(driver: WebDriver) -> None:
+    """Detect and close popups inside a Nexacro application."""
+    js = """
+try {
+    let app = nexacro.getApplication();
+    let targets = [
+        app.mainframe.HFrameSet00.frames?.[0]?.form,
+        app.mainframe.HFrameSet00?.VFrameSet00?.FrameSet?.WorkFrame?.form
+    ];
+    for (let form of targets) {
+        if (!form) continue;
+        for (let name in form.all) {
+            let comp = form.all[name];
+            if (
+                (comp instanceof nexacro.Div ||
+                 comp instanceof nexacro.PopupDiv ||
+                 comp instanceof nexacro.ChildFrame) &&
+                comp.visible
+            ) {
+                if (typeof comp.set_visible === "function") {
+                    comp.set_visible(false);
+                } else if (typeof comp.close === "function") {
+                    comp.close();
+                } else if (comp.btn_close && typeof comp.btn_close.click === "function") {
+                    comp.btn_close.click();
+                }
+            }
+        }
+    }
+    return 'ok';
+} catch (e) {
+    return 'error: ' + e.toString();
+}
+"""
+    try:
+        result = driver.execute_script(js)
+        log("close", "INFO", f"팝업 처리 결과: {result}")
+    except Exception as e:
+        log("close", "ERROR", f"스크립트 실행 실패: {e}")


### PR DESCRIPTION
## Summary
- add `close_nexacro_popups` util to detect and close popups
- call popup cleaner after successful login

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6868b3fdab8883208c5c0662fefe12a4