### PR TITLE
Integrate focus popup closing step

### DIFF
--- a/bgf_login_project/login/login_bgf.py
+++ b/bgf_login_project/login/login_bgf.py
@@ -4,7 +4,7 @@ import json
 import time
 
 from utils.log_util import create_logger
-from utils.popup_util import close_nexacro_popups
+from utils.popup_util import close_nexacro_popups, close_focus_popup
 
 log = create_logger("login_bgf")
 
@@ -86,6 +86,7 @@ try {
         if success:
             log("login", "SUCCESS", "Login succeeded")
             try:
+                close_focus_popup(driver)
                 close_nexacro_popups(driver)
             except Exception as e:
                 log("login", "WARNING", f"Popup close failed: {e}")

--- a/bgf_login_project/utils/popup_util.py
+++ b/bgf_login_project/utils/popup_util.py
@@ -1,5 +1,9 @@
 from selenium.webdriver.remote.webdriver import WebDriver
 from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.common.action_chains import ActionChains
+from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.common.by import By
+import time
 
 from .log_util import create_logger
 
@@ -47,3 +51,21 @@ try {
         log("close", "INFO", f"팝업 처리 결과: {result}")
     except Exception as e:
         log("close", "ERROR", f"스크립트 실행 실패: {e}")
+
+
+def close_focus_popup(driver: WebDriver, timeout: int = 5) -> None:
+    """"재택 유선권장 안내" 팝업을 엔터 키로 닫는다."""
+
+    end_time = time.time() + timeout
+    while time.time() < end_time:
+        try:
+            popup = driver.find_element(By.XPATH, "//div[contains(text(), '재택 유선권장 안내')]")
+            if popup.is_displayed():
+                log("focus_popup", "INFO", "팝업 감지됨: 엔터로 종료 시도")
+                ActionChains(driver).send_keys(Keys.ENTER).perform()
+                log("focus_popup", "INFO", "엔터 키 전송 완료")
+                return
+        except Exception as e:
+            log("focus_popup", "DEBUG", f"팝업 탐색 오류 또는 미표시: {e}")
+        time.sleep(0.5)
+    log("focus_popup", "DEBUG", "대상 팝업을 찾지 못함")


### PR DESCRIPTION
## Summary
- extend popup utility with `close_focus_popup` to handle the "재택 유선권장 안내" window
- invoke `close_focus_popup` in login sequence before existing popup handler

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6868e3af9d688320835b7d24df8e1d66