### PR TITLE
Fix grid parse checks and add loading delay

### DIFF
--- a/bgf_login_project/analysis/__init__.py
+++ b/bgf_login_project/analysis/__init__.py
@@ -55,6 +55,7 @@ def go_to_category_mix_ratio(driver: WebDriver) -> bool:
         return False
 
     print("[navigation] '중분류별 매출 구성비' 클릭 성공")
+    time.sleep(2)
     return True
 
 
@@ -102,4 +103,8 @@ def parse_mix_ratio_data(driver: WebDriver):
         "map(el => el.innerText)"
     )
     rows = driver.execute_script(script)
-    return pd.DataFrame({'code': rows}) if rows else None
+    if rows:
+        print(f"[parse_mix_ratio_data] {len(rows)}개 행 추출")
+        return pd.DataFrame({'code': rows})
+    print("[parse_mix_ratio_data][WARN] 추출된 행이 없음")
+    return None

--- a/bgf_login_project/main.py
+++ b/bgf_login_project/main.py
@@ -38,7 +38,11 @@ def main() -> None:
 
     try:
         df = parse_mix_ratio_data(driver)
-        print(df.head())
+        if df is None:
+            print("[analysis][ERROR] 그리드에서 코드 데이터를 가져올 수 없음")
+            driver.save_screenshot("fail_parse_mix_ratio.png")
+        else:
+            print(df.head())
     except Exception as e:
         print("analysis error", e)
 


### PR DESCRIPTION
## Summary
- delay after navigating to '중분류별 매출 구성비' screen
- provide debugging logs when extracting grid data
- handle missing grid data in `main.py`

## Testing
- `python -m py_compile bgf_login_project/main.py bgf_login_project/analysis/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_686a52f79d508320a4dadb839e76d4bb