### PR TITLE
Fix product extractor loop and selector

### DIFF
--- a/bgf_retail_project/analysis/__init__.py
+++ b/bgf_retail_project/analysis/__init__.py
@@ -209,13 +209,16 @@ return [...document.querySelectorAll("div")]
         return None
 
 
-def extract_product_info(driver: WebDriver, output_file: str | None = None, delay: float = 1.0) -> None:
+def extract_product_info(
+    driver: WebDriver, output_file: str | None = None, delay: float = 1.0
+) -> None:
     """중분류 코드별 상품 정보를 추출하여 텍스트 파일에 저장한다.
 
+    이 함수는 코드 셀 클릭부터 상품 행 순회까지 한 번의 루프에서 처리한다.
     매출 구성비 화면에서 왼쪽 코드(gdList)를 순차적으로 클릭한 뒤,
     오른쪽 상품 그리드(gdDetail)의 4개 행을 클릭하며 모든 상품 정보를
-    수집한다. 각 상품 행에서 ``cell_0_0:text`` 부터 ``cell_0_6:text``
-    의 값을 읽어 ``code | category | 상품코드 | 상품명 | 매출 | 발주 | 매입 | 폐기 | 현재고``
+    수집한다. 각 상품 행에서 ``cell_0_0:text`` 부터 ``cell_0_6:text`` 의
+    값을 읽어 ``code | category | 상품코드 | 상품명 | 매출 | 발주 | 매입 | 폐기 | 현재고``
     형식으로 ``output_file`` 경로에 한 줄씩 기록한다.
     """
 
@@ -258,7 +261,11 @@ return document.querySelector("div[id*='gdDetail'][id*='gridrow_0'][id*='cell_0_
             element,
         )
         category_name = driver.execute_script(
-            """var el = document.querySelector(`div#gridrow_${arguments[0]}.cell_${arguments[0]}_1:text`); return el?.innerText?.trim() || '';""",
+            """
+var selector = `div[id*="gridrow_${arguments[0]}"][id*="cell_${arguments[0]}_1:text"]`;
+var el = document.querySelector(selector);
+return el?.innerText?.trim() || '';
+""",
             row_index,
         )
 

--- a/bgf_retail_project/main.py
+++ b/bgf_retail_project/main.py
@@ -13,7 +13,6 @@ from bgf_retail_project.login.login_bgf import login_bgf
 from bgf_retail_project.analysis import (
     go_to_category_mix_ratio,
     parse_mix_ratio_data,
-    extract_code_details_strict_sequence,
     extract_product_info,
 )
 
@@ -46,11 +45,6 @@ def main() -> None:
             print(df.head())
     except Exception as e:
         print("analysis error", e)
-
-    try:
-        extract_code_details_strict_sequence(driver)
-    except Exception as e:
-        print("code detail extraction error", e)
 
     try:
         extract_product_info(driver)


### PR DESCRIPTION
## Summary
- avoid running the old code click loop separately
- clarify product extraction loop docstring
- fix selector for category name with a safe query

## Testing
- `python -m py_compile bgf_retail_project/analysis/__init__.py bgf_retail_project/main.py`

------
https://chatgpt.com/codex/tasks/task_e_686b386b5434832088cd38d4eeddaddd