### PR TITLE
Fix empty text handling in product extraction

### DIFF
--- a/bgf_retail_project/analysis/__init__.py
+++ b/bgf_retail_project/analysis/__init__.py
@@ -282,12 +282,12 @@ return el?.innerText?.trim() || '';
                 text = driver.execute_script(
                     """
 var el = document.querySelector(`div[id*='gridrow_0'][id*='cell_0_${arguments[0]}:text']`);
-return el?.innerText?.trim() || '';
+return el?.innerText?.trim() || "";
 """,
                     col,
                 )
-                if not text:
-                    print(f"[WARN] row 0 col {col} 텍스트 없음")
+                if text == "":
+                    print(f"[WARN] row 0 col {col} 텍스트 없음 (빈 문자열 처리됨)")
                 cols.append(text)
 
             if any(cols):


### PR DESCRIPTION
## Summary
- safeguard text extraction in `extract_product_info`
- warn explicitly when cell text is empty

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686b4266c6348320ad13f5cd521f4d8c