### PR TITLE
Improve grid utils product code clicking

### DIFF
--- a/analysis/__init__.py
+++ b/analysis/__init__.py
@@ -167,11 +167,10 @@ def click_all_product_codes(driver: WebDriver, delay: float = 1.0) -> int:
     수를 반환한다.
     """
 
-    seen: set[str] = set()
     total = 0
 
     while True:
-        count = grid_utils.click_all_visible_product_codes(driver, seen)
+        count = grid_utils.click_all_visible_product_codes(driver)
         total += count
         if count == 0:
             break

--- a/tests/test_grid_utils.py
+++ b/tests/test_grid_utils.py
@@ -73,16 +73,25 @@ def test_wait_for_grid_update_timeout():
         assert grid_utils.wait_for_grid_update(driver, "same", timeout=1.0) is False
 
 
-def test_click_all_visible_product_codes():
+def test_click_all_visible_product_codes_basic():
     driver = Mock()
     driver.execute_script.return_value = ["111", "222"]
 
-    seen = {"000"}
-    result = grid_utils.click_all_visible_product_codes(driver, seen)
+    result = grid_utils.click_all_visible_product_codes(driver)
 
     assert result == 2
-    assert seen == {"000", "111", "222"}
     driver.execute_script.assert_called_once()
     assert isinstance(driver.execute_script.call_args.args[0], str)
-    assert driver.execute_script.call_args.args[1] == ["000"]
+
+
+def test_click_all_visible_product_codes_polling():
+    driver = Mock()
+    driver.execute_script.side_effect = [[], ["333"]]
+
+    with patch.object(grid_utils.time, "sleep") as sleep_mock:
+        result = grid_utils.click_all_visible_product_codes(driver)
+
+    assert result == 1
+    assert driver.execute_script.call_count == 2
+    sleep_mock.assert_called_once_with(0.5)
 


### PR DESCRIPTION
## Summary
- handle clicked product codes entirely in browser context
- simplify click_all_product_codes now that state is stored in JS
- add polling to wait for delayed cells
- adjust tests to new helper API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c4653d38883209ed930689d23542a