### PR TITLE
Improve code cell selection

### DIFF
--- a/analysis/__init__.py
+++ b/analysis/__init__.py
@@ -286,26 +286,9 @@ def extract_product_info(
 
     for num in range(1, 901):
         code_str = f"{num:03}"
-        text_el = driver.execute_script(
-            """
-return [...document.querySelectorAll('div[id*="gdList"][id*="cell_"][id$="_0:text"]')]
-    .find(el => el.innerText?.trim() === arguments[0]);
-""",
-            code_str,
-        )
-
-        if not text_el:
-            log("category-skip", "INFO", f"'{code_str}' 텍스트 셀 없음")
-            continue
-
-        click_id = text_el.id.replace(':text', '')
-        element = driver.execute_script(
-            "return document.getElementById(arguments[0]);",
-            click_id,
-        )
-
+        element = grid_utils.find_clickable_cell_by_code(driver, code_str)
         if not element:
-            log("category-skip", "INFO", f"'{code_str}' 클릭 셀 없음")
+            log("category-skip", "INFO", f"'{code_str}' 클릭 가능한 셀 없음")
             continue
 
         safe_click_code_element(driver, element, code_str)

--- a/analysis/grid_utils.py
+++ b/analysis/grid_utils.py
@@ -93,3 +93,42 @@ return clicked;
         new_codes = _run_js()
 
     return len(new_codes)
+
+
+def wait_until_clickable(driver: WebDriver, click_id: str, timeout: int = 3):
+    """Return element when ``click_id`` exists and is visible within timeout."""
+    end = time.time() + timeout
+    while time.time() < end:
+        element = driver.execute_script(
+            "var el = document.getElementById(arguments[0]);"
+            "return el && el.offsetParent !== null ? el : null;",
+            click_id,
+        )
+        if element:
+            return element
+        time.sleep(0.1)
+    return None
+
+
+def find_clickable_cell_by_code(driver: WebDriver, code: str):
+    """Locate clickable grid cell for a given code.
+
+    Parameters
+    ----------
+    driver : WebDriver
+        Active Selenium instance.
+    code : str
+        Code text to search for.
+    """
+
+    text_el = driver.execute_script(
+        """
+return [...document.querySelectorAll('div[id*="gdList"][id*="cell_"][id$="_0:text"]')]
+  .find(el => el.innerText?.trim() === arguments[0]);
+""",
+        code,
+    )
+    if not text_el:
+        return None
+    click_id = driver.execute_script("return arguments[0].id.replace(':text', '')", text_el)
+    return wait_until_clickable(driver, click_id)

--- a/tests/test_grid_utils.py
+++ b/tests/test_grid_utils.py
@@ -95,3 +95,62 @@ def test_click_all_visible_product_codes_polling():
     assert driver.execute_script.call_count == 2
     sleep_mock.assert_called_once_with(0.5)
 
+
+def test_wait_until_clickable_success():
+    driver = Mock()
+    driver.execute_script.side_effect = [None, None, "el"]
+
+    fake_time = fake_time_generator()
+    with patch.object(grid_utils, "time") as tm:
+        tm.time.side_effect = fake_time
+        tm.sleep.side_effect = lambda x: None
+        result = grid_utils.wait_until_clickable(driver, "cid", timeout=1)
+
+    assert result == "el"
+    assert driver.execute_script.call_count == 3
+
+
+def test_wait_until_clickable_timeout():
+    driver = Mock()
+    driver.execute_script.return_value = None
+
+    fake_time = fake_time_generator()
+    with patch.object(grid_utils, "time") as tm:
+        tm.time.side_effect = fake_time
+        tm.sleep.side_effect = lambda x: None
+        result = grid_utils.wait_until_clickable(driver, "cid", timeout=1)
+
+    assert result is None
+
+
+def test_find_clickable_cell_by_code_success():
+    driver = Mock()
+    text_el = object()
+    driver.execute_script.side_effect = [text_el, "cid"]
+
+    with patch.object(grid_utils, "wait_until_clickable", return_value="el") as wuc:
+        result = grid_utils.find_clickable_cell_by_code(driver, "001")
+
+    assert result == "el"
+    assert wuc.call_args.args == (driver, "cid")
+
+
+def test_find_clickable_cell_by_code_no_text():
+    driver = Mock()
+    driver.execute_script.return_value = None
+
+    result = grid_utils.find_clickable_cell_by_code(driver, "001")
+
+    assert result is None
+
+
+def test_find_clickable_cell_by_code_not_clickable():
+    driver = Mock()
+    text_el = object()
+    driver.execute_script.side_effect = [text_el, "cid"]
+
+    with patch.object(grid_utils, "wait_until_clickable", return_value=None):
+        result = grid_utils.find_clickable_cell_by_code(driver, "001")
+
+    assert result is None
+


### PR DESCRIPTION
## Summary
- add helper functions to locate clickable cells
- switch product info scraper to new search logic
- cover new helpers with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686c4a711ecc83208bdee15fc6dfc4bc