### PR TITLE
Implement navigation helpers and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# BGF Retail Automation
+
+이 저장소는 BGF 리테일 시스템을 자동화하기 위한 실습용 코드 모음입니다. `analysis` 모듈에서 제공하는 함수들을 이용해 간단한 화면 전환이나 데이터 추출 작업을 수행할 수 있습니다.
+
+다음은 중분류별 매출구성비 화면으로 이동하는 예시입니다.
+
+```python
+from selenium.webdriver.remote.webdriver import WebDriver
+from analysis.navigation import go_to_mix_ratio_screen
+
+# driver는 로그인 이후의 WebDriver 인스턴스라고 가정합니다.
+if go_to_mix_ratio_screen(driver):
+    print("화면 이동 성공")
+else:
+    print("화면 이동 실패")
+```

--- a/analysis/__init__.py
+++ b/analysis/__init__.py
@@ -14,11 +14,13 @@ from selenium.webdriver.remote.webdriver import WebDriver
 from selenium.common.exceptions import WebDriverException
 
 from . import grid_utils
+from .navigation import click_menu_by_text, go_to_mix_ratio_screen
 from utils.log_util import create_logger
 
 __all__ = [
     "click_all_product_codes",
     "go_to_category_mix_ratio",
+    "go_to_mix_ratio_screen",
     "parse_mix_ratio_data",
     "extract_product_info",
 ]

--- a/analysis/navigation.py
+++ b/analysis/navigation.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from selenium.webdriver.remote.webdriver import WebDriver
+from selenium.webdriver.support.ui import WebDriverWait
+
+from utils.log_util import create_logger
+
+logger = create_logger("navigation")
+
+
+def click_menu_by_text(driver: WebDriver, text: str, timeout: int = 5) -> bool:
+    """Click a menu element matching ``text``.
+
+    The function searches all DOM nodes for an element whose ``innerText`` matches
+    ``text`` and clicks it using JavaScript. It returns ``True`` on success and
+    ``False`` on failure. Exceptions are logged as warnings.
+    """
+    try:
+        element = WebDriverWait(driver, timeout).until(
+            lambda d: d.execute_script(
+                "return [...document.querySelectorAll('*')]\n"
+                "    .find(el => el.innerText?.trim() === arguments[0]) || null;",
+                text,
+            )
+        )
+        driver.execute_script("arguments[0].click()", element)
+        return True
+    except Exception as e:  # pragma: no cover - defensive
+        logger("menu", "WARNING", f"click_menu_by_text failed: {e}")
+        return False
+
+
+def go_to_mix_ratio_screen(driver: WebDriver) -> bool:
+    """Navigate to the mix ratio screen via menu clicks."""
+
+    if not click_menu_by_text(driver, "영업분석"):
+        return False
+    if not click_menu_by_text(driver, "중분류별 매출구성비"):
+        return False
+    return True

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -9,10 +9,16 @@ selenium_pkg = types.ModuleType("selenium")
 webdriver_pkg = types.ModuleType("selenium.webdriver")
 remote_pkg = types.ModuleType("selenium.webdriver.remote")
 webdriver_module = types.ModuleType("selenium.webdriver.remote.webdriver")
+support_pkg = types.ModuleType("selenium.webdriver.support")
+ui_module = types.ModuleType("selenium.webdriver.support.ui")
+class WebDriverWait: ...
+ui_module.WebDriverWait = WebDriverWait
 class WebDriver: ...
 webdriver_module.WebDriver = WebDriver
 remote_pkg.webdriver = webdriver_module
 webdriver_pkg.remote = remote_pkg
+support_pkg.ui = ui_module
+webdriver_pkg.support = support_pkg
 common_pkg = types.ModuleType("selenium.common")
 exceptions_module = types.ModuleType("selenium.common.exceptions")
 class WebDriverException(Exception):
@@ -25,6 +31,8 @@ sys.modules.setdefault("selenium", selenium_pkg)
 sys.modules.setdefault("selenium.webdriver", webdriver_pkg)
 sys.modules.setdefault("selenium.webdriver.remote", remote_pkg)
 sys.modules.setdefault("selenium.webdriver.remote.webdriver", webdriver_module)
+sys.modules.setdefault("selenium.webdriver.support", support_pkg)
+sys.modules.setdefault("selenium.webdriver.support.ui", ui_module)
 sys.modules.setdefault("selenium.common", common_pkg)
 sys.modules.setdefault("selenium.common.exceptions", exceptions_module)
 

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -1,0 +1,76 @@
+import importlib.util
+import pathlib
+import sys
+import types
+from unittest.mock import Mock, patch
+
+# minimal fake selenium package
+selenium_pkg = types.ModuleType("selenium")
+webdriver_pkg = types.ModuleType("selenium.webdriver")
+remote_pkg = types.ModuleType("selenium.webdriver.remote")
+webdriver_module = types.ModuleType("selenium.webdriver.remote.webdriver")
+support_pkg = types.ModuleType("selenium.webdriver.support")
+ui_module = types.ModuleType("selenium.webdriver.support.ui")
+class WebDriverWait: ...
+ui_module.WebDriverWait = WebDriverWait
+
+class WebDriver:
+    ...
+
+webdriver_module.WebDriver = WebDriver
+remote_pkg.webdriver = webdriver_module
+webdriver_pkg.remote = remote_pkg
+support_pkg.ui = ui_module
+webdriver_pkg.support = support_pkg
+selenium_pkg.webdriver = webdriver_pkg
+
+sys.modules.setdefault("selenium", selenium_pkg)
+sys.modules.setdefault("selenium.webdriver", webdriver_pkg)
+sys.modules.setdefault("selenium.webdriver.remote", remote_pkg)
+sys.modules.setdefault("selenium.webdriver.remote.webdriver", webdriver_module)
+sys.modules.setdefault("selenium.webdriver.support", support_pkg)
+sys.modules.setdefault("selenium.webdriver.support.ui", ui_module)
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+_spec = importlib.util.spec_from_file_location(
+    "navigation",
+    pathlib.Path(__file__).resolve().parents[1] / "analysis" / "navigation.py",
+)
+navigation = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(navigation)
+
+
+def test_click_menu_by_text_success():
+    driver = Mock()
+    elem = object()
+    driver.execute_script.side_effect = [elem, None]
+
+    wait_mock = Mock()
+    wait_mock.until.side_effect = lambda func: func(driver)
+
+    with patch.object(navigation, "WebDriverWait", return_value=wait_mock):
+        result = navigation.click_menu_by_text(driver, "메뉴")
+
+    assert result is True
+    driver.execute_script.assert_called_with("arguments[0].click()", elem)
+
+
+def test_click_menu_by_text_failure():
+    driver = Mock()
+    wait_mock = Mock()
+    wait_mock.until.side_effect = Exception("no")
+
+    with patch.object(navigation, "WebDriverWait", return_value=wait_mock):
+        result = navigation.click_menu_by_text(driver, "메뉴")
+
+    assert result is False
+
+
+def test_go_to_mix_ratio_screen():
+    driver = Mock()
+    with patch.object(navigation, "click_menu_by_text", side_effect=[True, True]) as m:
+        assert navigation.go_to_mix_ratio_screen(driver) is True
+        assert m.call_count == 2
+
+    with patch.object(navigation, "click_menu_by_text", side_effect=[True, False]):
+        assert navigation.go_to_mix_ratio_screen(driver) is False


### PR DESCRIPTION
## Summary
- add `navigation` module with helpers for menu navigation
- expose `go_to_mix_ratio_screen` from `analysis`
- unit tests for new navigation functions
- update existing tests for new imports
- add README with simple usage example

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c56d860f8832088fed5d89217c56b