### PR TITLE
Integrate product exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,14 @@
 
 ```python
 from selenium.webdriver.remote.webdriver import WebDriver
-from analysis import navigate_to_category_mix_ratio
+from analysis import navigate_to_category_mix_ratio, export_product_data
 
 # driver는 로그인 이후의 WebDriver 인스턴스라고 가정합니다.
 if navigate_to_category_mix_ratio(driver):
     print("화면 이동 성공")
 else:
     print("화면 이동 실패")
+
+# 상품 데이터를 추출해 현재 디렉터리에 저장
+export_product_data(driver)
 ```

--- a/main.py
+++ b/main.py
@@ -9,6 +9,7 @@ from analysis import (
     parse_mix_ratio_data,
     extract_product_info,
     click_all_product_codes,
+    export_product_data,
 )
 
 def create_driver() -> webdriver.Chrome:
@@ -52,6 +53,15 @@ def main() -> None:
         extract_product_info(driver)
     except Exception as e:
         print("product info extraction error", e)
+
+    try:
+        output_path = export_product_data(driver, "code_outputs")
+        if output_path:
+            print(f"exported product data to {output_path}")
+        else:
+            print("export product data failed")
+    except Exception as e:
+        print("product export error", e)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- 연결된 product exporter 사용을 위해 main에 export 함수를 호출
- README 예시에 export_product_data 사용법 추가

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cbf6c08748320b64daeb004b435bc