### PR TITLE
Refactor product exporter

### DIFF
--- a/analysis/product_exporter.py
+++ b/analysis/product_exporter.py
@@ -1,11 +1,9 @@
 from __future__ import annotations
 
 import datetime
-import time
 from pathlib import Path
-from typing import Any
+from typing import Iterable, Mapping
 
-from selenium.webdriver.remote.webdriver import WebDriver
 from utils.log_util import create_logger
 
 
@@ -22,87 +20,37 @@ HEADER = [
 ]
 
 
-def _dispatch_click(driver: WebDriver, selector: str) -> None:
-    """Dispatch mousedown, mouseup and click events for the element."""
-    driver.execute_script(
-        """
-const el = document.querySelector(arguments[0]);
-if (el) {
-  const rect = el.getBoundingClientRect();
-  ['mousedown', 'mouseup', 'click'].forEach(type => {
-    el.dispatchEvent(new MouseEvent(type, {
-      bubbles: true,
-      cancelable: true,
-      view: window,
-      clientX: rect.left + rect.width / 2,
-      clientY: rect.top + rect.height / 2
-    }));
-  });
-}
-""",
-        selector,
-    )
+def export_product_data(
+    rows: Iterable[Mapping[str, str]],
+    output_dir: str | Path = ".",
+    delimiter: str = "\t",
+) -> Path:
+    """Save product data rows to a text file.
 
+    Parameters
+    ----------
+    rows:
+        상품 정보를 담은 ``dict`` 목록.
+    output_dir:
+        결과 파일을 저장할 디렉터리. 기본값은 현재 작업 디렉터리다.
+    delimiter:
+        열 구분자로 사용할 문자열. 기본값은 탭 문자("\t").
+    """
 
-def export_product_data(driver: WebDriver, output_dir: str | Path = ".") -> Path | None:
-    """Collect product info by clicking codes and save it as a text file."""
     log = create_logger("export")
-    from . import parse_mix_ratio_data
 
-    df = parse_mix_ratio_data(driver)
-    if df is None:
-        log("export", "ERROR", "카테고리 데이터 없음")
-        return None
-
-    rows: list[list[str]] = []
-
-    for idx, cat in df.iterrows():
-        mid_code = cat.get("code", "")
-        mid_text = cat.get("name", "") or ""
-        _dispatch_click(driver, f"div[id^='gdList.gridrow_{idx}'] > div[id$='.cell_{idx}_0']")
-        time.sleep(0.5)
-
-        # 상품 코드 목록 추출 (프론트엔드에서 제공하는 가정)
-        try:
-            product_codes: list[str] = driver.execute_script(
-                "return window.__CODEX__?.productCodes || []"
-            )
-        except Exception as e:
-            log("export", "WARNING", f"상품 코드 목록 조회 실패: {e}")
-            continue
-
-        for p_idx, p_code in enumerate(product_codes):
-            _dispatch_click(driver, f"div[id^='gdDetail.gridrow_{p_idx}'] > div[id$='.cell_{p_idx}_0']")
-            time.sleep(0.3)
-            time.sleep(0.1)
-            try:
-                data: dict[str, Any] = driver.execute_script(
-                    "return window.__CODEX__?.currentRow || {}"
-                )
-            except Exception as e:
-                log("export", "WARNING", f"행 데이터 조회 실패: {e}")
-                data = {}
-
-            row = [
-                mid_code,
-                mid_text,
-                str(data.get("상품코드") or data.get("code") or p_code),
-                str(data.get("상품명") or data.get("name") or ""),
-                str(data.get("매출") or data.get("sales") or ""),
-                str(data.get("발주") or data.get("order") or ""),
-                str(data.get("매입") or data.get("purchase") or ""),
-                str(data.get("폐기") or data.get("dispose") or ""),
-                str(data.get("현재고") or data.get("stock") or ""),
-            ]
-            rows.append(row)
-
+    data = list(rows)
     output_dir = Path(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
+
     filename = datetime.date.today().strftime("%Y%m%d.txt")
     path = output_dir / filename
+
     with open(path, "w", encoding="utf-8") as f:
-        f.write("\t".join(HEADER) + "\n")
-        for r in rows:
-            f.write("\t".join(r) + "\n")
-    log("export", "INFO", f"총 {len(rows)}행 저장: {path}")
+        f.write(delimiter.join(HEADER) + "\n")
+        for row in data:
+            values = [str(row.get(col, "")) for col in HEADER]
+            f.write(delimiter.join(values) + "\n")
+
+    log("export", "INFO", f"총 {len(data)}행 저장: {path}")
     return path

--- a/tests/test_product_exporter.py
+++ b/tests/test_product_exporter.py
@@ -1,31 +1,9 @@
 import importlib.util
 import pathlib
 import sys
-import types
-from unittest.mock import Mock, patch
-
-# minimal fake selenium package
-selenium_pkg = types.ModuleType("selenium")
-webdriver_pkg = types.ModuleType("selenium.webdriver")
-remote_pkg = types.ModuleType("selenium.webdriver.remote")
-webdriver_module = types.ModuleType("selenium.webdriver.remote.webdriver")
-class WebDriver: ...
-webdriver_module.WebDriver = WebDriver
-remote_pkg.webdriver = webdriver_module
-webdriver_pkg.remote = remote_pkg
-selenium_pkg.webdriver = webdriver_pkg
-sys.modules.setdefault("selenium", selenium_pkg)
-sys.modules.setdefault("selenium.webdriver", webdriver_pkg)
-sys.modules.setdefault("selenium.webdriver.remote", remote_pkg)
-sys.modules.setdefault("selenium.webdriver.remote.webdriver", webdriver_module)
+from unittest.mock import patch
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
-analysis_spec = importlib.util.spec_from_file_location(
-    "analysis", pathlib.Path(__file__).resolve().parents[1] / "analysis" / "__init__.py"
-)
-analysis = importlib.util.module_from_spec(analysis_spec)
-sys.modules["analysis"] = analysis
-analysis_spec.loader.exec_module(analysis)
 
 spec = importlib.util.spec_from_file_location(
     "analysis.product_exporter",
@@ -36,45 +14,31 @@ sys.modules["analysis.product_exporter"] = product_exporter
 spec.loader.exec_module(product_exporter)
 
 
-class DummyDF:
-    def __init__(self):
-        self._rows = [
-            {"code": "201", "name": "음료"},
-        ]
-
-    def iterrows(self):
-        for idx, row in enumerate(self._rows):
-            yield idx, row
-
-
 def test_export_product_data_writes_file(tmp_path):
-    driver = Mock()
-    driver.execute_script.side_effect = [
-        None,
-        ["8801234567890"],
-        None,
+    rows = [
         {
+            "중분류코드": "201",
+            "중분류텍스트": "음료",
             "상품코드": "8801234567890",
             "상품명": "주)압도적리치참치마요2",
             "매출": "1",
             "발주": "1",
-            "매입": "0",
+            "매입": "",
             "폐기": "0",
-            "현재고": "3",
-        },
+            "현재고": "",
+        }
     ]
 
-    df = DummyDF()
     class D(product_exporter.datetime.date):
         @classmethod
         def today(cls):
             return cls(2025, 7, 8)
 
-    with patch.object(analysis, "parse_mix_ratio_data", return_value=df), \
-         patch.object(product_exporter.time, "sleep"), \
-         patch.object(product_exporter.datetime, "date", D):
-        path = product_exporter.export_product_data(driver, tmp_path)
+    with patch.object(product_exporter.datetime, "date", D):
+        path = product_exporter.export_product_data(rows, tmp_path)
 
     assert path.name == "20250708.txt"
     assert path.exists()
-    driver.execute_script.assert_called()
+    lines = path.read_text(encoding="utf-8").splitlines()
+    assert lines[0] == "\t".join(product_exporter.HEADER)
+    assert lines[1].split("\t")[2] == "8801234567890"


### PR DESCRIPTION
## Summary
- redesign `export_product_data` to accept pre-collected product info
- simplify test for new exporter behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cc38374548320857a91aba09eaafd