### PR TITLE
Implement extract_product_info and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,11 @@
 
 ```python
 from selenium.webdriver.remote.webdriver import WebDriver
-from analysis import navigate_to_category_mix_ratio, export_product_data
+from analysis import (
+    navigate_to_category_mix_ratio,
+    extract_product_info,
+    export_product_data,
+)
 
 # driver는 로그인 이후의 WebDriver 인스턴스라고 가정합니다.
 if navigate_to_category_mix_ratio(driver):
@@ -15,5 +19,6 @@ else:
     print("화면 이동 실패")
 
 # 상품 데이터를 추출해 현재 디렉터리에 저장
-export_product_data(driver)
+rows = extract_product_info(driver) or []
+export_product_data(rows)
 ```

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -65,3 +65,16 @@ def test_click_all_product_codes_executes_js():
     analysis.click_all_product_codes(driver)
 
     driver.execute_script.assert_called_once()
+
+
+def test_extract_product_info_returns_rows():
+    driver = Mock()
+    driver.execute_script.side_effect = [True, [{"상품코드": "1"}]]
+
+    with patch.object(analysis.time, "sleep"), patch.object(
+        analysis, "create_logger", return_value=lambda *a: None
+    ):
+        rows = analysis.extract_product_info(driver)
+
+    assert rows == [{"상품코드": "1"}]
+    assert driver.execute_script.call_count == 2


### PR DESCRIPTION
## Summary
- implement `extract_product_info` to read product grid rows
- update README usage example
- add tests for new product extractor

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cc6c260688320bc6584d9e878d426