### PR TITLE
Revert product grid grid_auto_clicker modifications

### DIFF
--- a/analysis/grid_auto_clicker.js
+++ b/analysis/grid_auto_clicker.js
@@ -51,9 +51,6 @@
 
     while (true) {
       const textCells = [...document.querySelectorAll("div[id*='gdDetail.body'][id*='cell_'][id$='_0:text']")];
-      if (textCells.length === 0) {
-        console.warn("❗ 상품 목록 비어 있음 → 렌더링 실패 가능성");
-      }
       const newCodes = [];
 
       for (const textEl of textCells) {
@@ -122,7 +119,7 @@
         seenMid.add(code);
         newMids.push(code);
         console.log(`✅ 중분류 클릭 완료: ${code}`);
-        await delay(800);  // 중분류 클릭 후 화면 렌더링 대기 (렌더링 안정성 확보)
+        await delay(500);  // 중분류 클릭 후 화면 렌더링 대기
 
         await autoClickAllProductCodes(code, midName); // 상품코드 클릭 루프 진입
         await delay(300); // 다음 중분류 넘어가기 전 딜레이


### PR DESCRIPTION
## Summary
- revert earlier changes in `grid_auto_clicker.js` that inserted empty-grid checks and increased wait time

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cd58eb5ac832096d7dfc8513c2b01