### PR TITLE
Add wait loop for product cells

### DIFF
--- a/analysis/grid_auto_clicker.js
+++ b/analysis/grid_auto_clicker.js
@@ -49,6 +49,14 @@
     const seen = new Set();
     let scrollCount = 0;
 
+    let attempts = 0;
+    while (
+      document.querySelectorAll("div[id*='gdDetail.body'][id$='_0:text']").length === 0 &&
+      attempts++ < 10
+    ) {
+      await delay(300);
+    }
+
     while (true) {
       const textCells = [...document.querySelectorAll("div[id*='gdDetail.body'][id*='cell_'][id$='_0:text']")];
       const newCodes = [];


### PR DESCRIPTION
## Summary
- wait until at least one product cell is available before clicking products

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cda8d7090832098d1c743f22b5951