### PR TITLE
Fix row index regex for Nexacro DOM

### DIFF
--- a/analysis/grid_auto_clicker.js
+++ b/analysis/grid_auto_clicker.js
@@ -66,7 +66,9 @@
         if (!/^\d{13}$/.test(code)) continue;
         if (seen.has(code)) continue;
 
-        const rowIdx = textEl.id.match(/cell_(\d+)_0:text$/)?.[1];
+        const rowIdx = textEl
+          .closest("div[id*='gridrow_']")
+          ?.id.match(/gridrow_(\d+)/)?.[1];
         if (rowIdx !== undefined) {
           collectRowData(rowIdx, midCode, midName);
         }


### PR DESCRIPTION
## Summary
- extract row index from `gridrow_` element instead of using cell pattern

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d0968c1c48320834b2df4e41243df