### PR TITLE
Handle click script load errors

### DIFF
--- a/analysis/__init__.py
+++ b/analysis/__init__.py
@@ -32,14 +32,17 @@ def click_all_product_codes(
 ) -> None:
     """Run the JavaScript auto clicker inside the browser."""
 
+    logger = create_logger("analysis")
+
     if script_path is None:
         script_path = str(Path(__file__).with_name("grid_auto_clicker.js"))
 
     try:
         with open(script_path, "r", encoding="utf-8") as f:
             js = f.read()
-    except OSError:
-        return None
+    except OSError as e:
+        logger("click", "ERROR", f"script load failed: {e}")
+        raise
 
     driver.execute_script(js)
 

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -3,6 +3,7 @@ import pathlib
 import sys
 import types
 from unittest.mock import Mock, patch
+import pytest
 
 # minimal fake selenium package
 selenium_pkg = types.ModuleType("selenium")
@@ -78,3 +79,19 @@ def test_extract_product_info_returns_rows():
 
     assert rows == [{"상품코드": "1"}]
     assert driver.execute_script.call_count == 2
+
+
+def test_click_all_product_codes_logs_and_raises(tmp_path):
+    driver = Mock()
+    missing = tmp_path / "no.js"
+
+    logger = Mock()
+    with patch.object(analysis, "create_logger", return_value=logger):
+        with pytest.raises(OSError):
+            analysis.click_all_product_codes(driver, str(missing))
+
+    logger.assert_called_once()
+    tag, level, msg = logger.call_args[0]
+    assert tag == "click"
+    assert level == "ERROR"
+


### PR DESCRIPTION
## Summary
- log and rethrow errors when loading `grid_auto_clicker.js`
- test error handling logic for missing script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e114e7ea88320b980c2616d6fa3ee