### PR TITLE
Improve popup handling after login

### DIFF
--- a/login/login_bgf.py
+++ b/login/login_bgf.py
@@ -5,7 +5,11 @@ import os
 import time
 
 from utils.log_util import create_logger
-from utils.popup_util import close_nexacro_popups, close_focus_popup
+from utils.popup_util import (
+    close_nexacro_popups,
+    close_focus_popup,
+    ensure_focus_popup_closed,
+)
 
 log = create_logger("login_bgf")
 
@@ -123,6 +127,7 @@ try {
             log("login", "SUCCESS", "Login succeeded")
             try:
                 close_focus_popup(driver)
+                ensure_focus_popup_closed(driver)
                 close_nexacro_popups(driver)
             except Exception as e:
                 log("login", "WARNING", f"Popup close failed: {e}")


### PR DESCRIPTION
## Summary
- close the focus popup until it no longer reappears
- use `ensure_focus_popup_closed` when logging in to keep the popup closed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f7e11c9b88320b6c725e6ec98772c