### PR TITLE
Handle popups after TensorFlow delegate log

### DIFF
--- a/main.py
+++ b/main.py
@@ -8,8 +8,10 @@ from typing import Any
 from selenium import webdriver
 from selenium.webdriver.chrome.service import Service
 from selenium.webdriver.chrome.options import Options
+from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
 
 from login.login_bgf import login_bgf
+from utils.popup_util import close_popups_after_delegate
 
 
 def click_login_button(driver: webdriver.Chrome) -> None:
@@ -32,7 +34,9 @@ SCRIPT_DIR = Path(__file__).with_name("scripts")
 def create_driver() -> webdriver.Chrome:
     options = Options()
     options.add_experimental_option("detach", True)
-    return webdriver.Chrome(service=Service(), options=options)
+    caps = DesiredCapabilities.CHROME.copy()
+    caps["goog:loggingPrefs"] = {"browser": "ALL"}
+    return webdriver.Chrome(service=Service(), options=options, desired_capabilities=caps)
 
 
 def run_script(driver: webdriver.Chrome, name: str) -> Any:
@@ -75,6 +79,12 @@ def main() -> None:
         print("login failed")
         driver.quit()
         return
+
+    # TensorFlow delegate 초기화 로그 이후 다시 팝업을 닫는다
+    try:
+        close_popups_after_delegate(driver)
+    except Exception as e:
+        print(f"delegate popup close failed: {e}")
 
     # 로그인 버튼 클릭만 필요한 경우를 위해 별도 호출
     click_login_button(driver)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -13,6 +13,8 @@ webdriver_module = types.ModuleType("selenium.webdriver.remote.webdriver")
 chrome_pkg = types.ModuleType("selenium.webdriver.chrome")
 service_pkg = types.ModuleType("selenium.webdriver.chrome.service")
 options_pkg = types.ModuleType("selenium.webdriver.chrome.options")
+common_pkg = types.ModuleType("selenium.webdriver.common")
+dcaps_pkg = types.ModuleType("selenium.webdriver.common.desired_capabilities")
 
 class WebDriver: ...
 class Service: ...
@@ -29,6 +31,16 @@ webdriver_pkg.remote = remote_pkg
 webdriver_pkg.chrome = chrome_pkg
 chrome_pkg.service = service_pkg
 chrome_pkg.options = options_pkg
+webdriver_pkg.common = common_pkg
+common_pkg.desired_capabilities = dcaps_pkg
+
+class DesiredCapabilities:
+    CHROME = {}
+dcaps_pkg.DesiredCapabilities = DesiredCapabilities
+
+class DesiredCapabilities:
+    CHROME = {}
+dcaps_pkg.DesiredCapabilities = DesiredCapabilities
 
 selenium_pkg.webdriver = webdriver_pkg
 sys.modules.setdefault("selenium", selenium_pkg)
@@ -38,6 +50,10 @@ sys.modules.setdefault("selenium.webdriver.remote.webdriver", webdriver_module)
 sys.modules.setdefault("selenium.webdriver.chrome", chrome_pkg)
 sys.modules.setdefault("selenium.webdriver.chrome.service", service_pkg)
 sys.modules.setdefault("selenium.webdriver.chrome.options", options_pkg)
+sys.modules.setdefault("selenium.webdriver.common", common_pkg)
+sys.modules.setdefault("selenium.webdriver.common.desired_capabilities", dcaps_pkg)
+sys.modules.setdefault("selenium.webdriver.common", common_pkg)
+sys.modules.setdefault("selenium.webdriver.common.desired_capabilities", dcaps_pkg)
 
 # dummy login module
 login_pkg = types.ModuleType("login")
@@ -48,6 +64,12 @@ login_bgf_pkg.login_bgf = dummy_login_bgf
 login_pkg.login_bgf = login_bgf_pkg
 sys.modules.setdefault("login", login_pkg)
 sys.modules.setdefault("login.login_bgf", login_bgf_pkg)
+
+popup_pkg = types.ModuleType("utils.popup_util")
+def dummy_close_popups_after_delegate(*a, **k):
+    pass
+popup_pkg.close_popups_after_delegate = dummy_close_popups_after_delegate
+sys.modules.setdefault("utils.popup_util", popup_pkg)
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
 _spec = importlib.util.spec_from_file_location(

--- a/utils/popup_util.py
+++ b/utils/popup_util.py
@@ -105,3 +105,20 @@ def ensure_focus_popup_closed(
         time.sleep(0.2)
 
     log("focus_popup", "WARNING", "타임아웃: 팝업 상태 불안정")
+
+def close_popups_after_delegate(driver: WebDriver, timeout: int = 10) -> None:
+    """TensorFlow Lite delegate 로그 이후 팝업을 다시 닫는다."""
+    end_time = time.time() + timeout
+    while time.time() < end_time:
+        try:
+            logs = driver.get_log("browser")
+        except Exception:
+            logs = []
+        for entry in logs:
+            msg = entry.get("message", "") if isinstance(entry, dict) else str(entry)
+            if "Created TensorFlow Lite XNNPACK delegate for CPU" in msg:
+                close_focus_popup(driver)
+                ensure_focus_popup_closed(driver)
+                close_nexacro_popups(driver)
+                return
+        time.sleep(0.5)


### PR DESCRIPTION
## Summary
- watch Chrome logs for the TensorFlow Lite delegate message
- close popups again when the delegate initializes
- expose browser logs from Chrome driver
- stub popup utility and DesiredCapabilities for tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f8295971483208ce0ec3efdbbb50c