### PR TITLE
Add logs for post-popup transitions

### DIFF
--- a/login/login_bgf.py
+++ b/login/login_bgf.py
@@ -131,6 +131,8 @@ try {
                 close_nexacro_popups(driver)
             except Exception as e:
                 log("login", "WARNING", f"Popup close failed: {e}")
+            else:
+                log("login", "INFO", "팝업 모듈 종료: 다음 단계 진입")
             return True
     log("login", "FAIL", "Login check timeout")
     return False

--- a/utils/popup_util.py
+++ b/utils/popup_util.py
@@ -134,5 +134,6 @@ def close_popups_after_delegate(driver: WebDriver, timeout: int = 10) -> None:
                 close_focus_popup(driver)
                 ensure_focus_popup_closed(driver)
                 close_nexacro_popups(driver)
+                log("delegate", "INFO", "팝업 모듈 처리 후 다음 단계 진입")
                 return
         time.sleep(0.5)


### PR DESCRIPTION
## Summary
- log when popup handling finishes in `login_bgf`
- log when delegate popup handler finishes in `popup_util`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871ee8b8c048320807b69d701527813