### PR TITLE
Add logging to mid-category click JS

### DIFF
--- a/scripts/click_all_mid_categories.js
+++ b/scripts/click_all_mid_categories.js
@@ -1,10 +1,11 @@
 (() => {
+  const logs = [];
   const cells = [...document.querySelectorAll("div[id*='gdList.body'][id$='_0:text']")];
   cells.forEach(cell => {
     const target = document.getElementById(cell.id.replace(':text', ''));
     if (target) {
       const rect = target.getBoundingClientRect();
-      ['mousedown','mouseup','click'].forEach(type => {
+      ['mousedown', 'mouseup', 'click'].forEach(type => {
         target.dispatchEvent(new MouseEvent(type, {
           bubbles: true,
           cancelable: true,
@@ -13,6 +14,11 @@
           clientY: rect.top + rect.height / 2
         }));
       });
+      logs.push({ code: cell.innerText.trim(), status: 'success' });
+    } else {
+      logs.push({ code: cell.innerText.trim(), status: 'not-found' });
     }
   });
+  window.__midCategoryLogs__ = logs;
+  console.log('mid category click logs', logs);
 })();


### PR DESCRIPTION
## Summary
- add console logs and collect click result status in `click_all_mid_categories.js`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68723a6258ec83208db891a80e514bd0