### PR TITLE
Update save_to_txt to respect field order

### DIFF
--- a/main.py
+++ b/main.py
@@ -18,6 +18,18 @@ from analysis import navigate_to_category_mix_ratio
 SCRIPT_DIR = Path(__file__).with_name("scripts")
 CODE_OUTPUT_DIR = Path(__file__).with_name("code_outputs")
 
+# output.txt 필드 저장 순서를 지정한다.
+FIELD_ORDER = [
+    "midCode",
+    "productCode",
+    "productName",
+    "sales",
+    "order",
+    "purchase",
+    "discard",
+    "stock",
+]
+
 
 def create_driver() -> webdriver.Chrome:
     options = Options()
@@ -60,7 +72,10 @@ def save_to_txt(data: Any, output: str | Path | None = None) -> Path:
         if isinstance(data, list):
             for row in data:
                 if isinstance(row, dict):
-                    f.write("\t".join(str(v) for v in row.values()) + "\n")
+                    # 필드 순서에 맞춰 값을 가져온 뒤 탭으로 구분하여 기록한다.
+                    f.write(
+                        "\t".join(str(row.get(k, "")) for k in FIELD_ORDER) + "\n"
+                    )
                 else:
                     f.write(str(row) + "\n")
         else:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -103,7 +103,18 @@ def test_wait_for_data_polls_parsed_data():
 
 
 def test_save_to_txt_writes_to_date_file(tmp_path):
-    data = [{"code": "1", "name": "a"}]
+    data = [
+        {
+            "midCode": "1",
+            "productCode": "2",
+            "productName": "a",
+            "sales": 3,
+            "order": 4,
+            "purchase": 5,
+            "discard": 6,
+            "stock": 7,
+        }
+    ]
     out_dir = tmp_path / "code_outputs"
     out_dir.mkdir()
     fname = datetime.now().strftime("%Y%m%d") + ".txt"
@@ -112,7 +123,8 @@ def test_save_to_txt_writes_to_date_file(tmp_path):
     returned = main.save_to_txt(data, out_file)
 
     assert returned == out_file
-    assert out_file.read_text(encoding="utf-8").strip() == "1\ta"
+    expected = "\t".join(str(data[0].get(k, "")) for k in main.FIELD_ORDER)
+    assert out_file.read_text(encoding="utf-8").strip() == expected
 
 
 def test_main_calls_navigation():


### PR DESCRIPTION
## Summary
- ensure dictionary rows are written in FIELD_ORDER
- add FIELD_ORDER constant
- update tests for new field order

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872f5179e8083208ee0712c7b7c531f