### PR TITLE
Support nested output directories

### DIFF
--- a/main.py
+++ b/main.py
@@ -66,6 +66,7 @@ def save_to_txt(data: Any, output: str | Path | None = None) -> Path:
         fname = datetime.now().strftime("%Y%m%d") + ".txt"
         output = CODE_OUTPUT_DIR / fname
     output = Path(output)
+    output.parent.mkdir(parents=True, exist_ok=True)
     if output.exists():
         output.unlink()
     with open(output, "w", encoding="utf-8") as f:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -148,6 +148,12 @@ def test_save_to_txt_field_order(tmp_path):
     assert contents == [str(data[0].get(k, "")) for k in main.FIELD_ORDER]
 
 
+def test_save_to_txt_creates_parent_dir(tmp_path):
+    out_file = tmp_path / "nested" / "dir" / "out.txt"
+    main.save_to_txt(["a"], out_file)
+    assert out_file.exists()
+
+
 def test_main_calls_navigation():
     driver = Mock()
 


### PR DESCRIPTION
## Summary
- ensure `save_to_txt` creates parent directories before writing
- test that nested output paths work automatically

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873420e926883209c712e39a4319d54