### PR TITLE
Remove grid loading wait in navigation

### DIFF
--- a/analysis/navigation.py
+++ b/analysis/navigation.py
@@ -11,22 +11,6 @@ MAIN_MENU_ID = (
 )
 
 
-def _wait_for_list_grid(driver: WebDriver, timeout: int = 5) -> bool:
-    """좌측 그리드 셀이 표시될 때까지 대기한다."""
-    end_time = time.time() + timeout
-    while time.time() < end_time:
-        try:
-            exists = driver.execute_script(
-                r"""
-return document.querySelector("div[id*='gdList.body'][id$='_0:text']") !== null
-"""
-            )
-            if exists:
-                return True
-        except Exception:
-            pass
-        time.sleep(0.5)
-    return False
 
 
 def navigate_to_category_mix_ratio(driver: WebDriver) -> bool:
@@ -102,11 +86,6 @@ return true;
 
     if not clicked:
         log("nav", "ERROR", "❌ '중분류별 매출 구성비' 클릭 실패")
-        return False
-
-    log("nav", "INFO", "⌛ 좌측 그리드 로딩 대기")
-    if not _wait_for_list_grid(driver, timeout=5):
-        log("nav", "ERROR", "❌ 좌측 그리드 로딩 실패")
         return False
 
     log("nav", "SUCCESS", "✅ 메뉴 진입 완료")

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -30,7 +30,7 @@ _spec.loader.exec_module(navigation)
 
 def test_navigate_success():
     driver = Mock()
-    driver.execute_script.side_effect = [True, True, True]
+    driver.execute_script.side_effect = [True, True]
 
     with patch.object(navigation.time, "sleep"), patch.object(navigation, "create_logger", return_value=lambda *a: None):
         assert navigation.navigate_to_category_mix_ratio(driver) is True


### PR DESCRIPTION
## Summary
- 화면 이동 중 좌측 그리드 로딩 대기 로직을 삭제했습니다.
- 테스트에서는 이에 맞춰 `driver.execute_script` 호출 횟수를 수정했습니다.

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875844a0dc48320ab7413cfb9685d27