### PR TITLE
Add product data collection from visible grid

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,10 @@ python -m aaa  # 또는 python main.py
 
 `main.py` 는 Chrome 드라이버를 생성하고 `scripts/` 폴더의 JavaScript 파일을
 실행합니다. 기본 제공 스크립트는 `click_and_extract.js` 로,
-중분류 코드를 클릭한 뒤 상세 데이터를 추출합니다.
+중분류 코드를 클릭한 뒤 상세 데이터를 추출합니다. 상품을 클릭할 때마다
+`collectVisibleProducts()` 가 호출되어 화면에 표시된 상품 정보가
+`window.__productList` 에 차곡차곡 쌓입니다. 호출 위치는
+`autoClickAllProductCodes()` 함수의 `await delay(300);` 다음입니다.
 
 실행이 끝나면 파싱된 데이터가 `code_outputs/날짜.txt` 형식으로 저장됩니다. 각 행에는 중분류 코드,
 상품코드, 상품명 외에도 매출ㆍ발주ㆍ매입ㆍ폐기ㆍ현재고 값이 함께 기록됩니다. 빈 셀은

--- a/scripts/click_and_extract.js
+++ b/scripts/click_and_extract.js
@@ -17,6 +17,56 @@
     return true;
   }
 
+  /**
+   * 현재 선택된 중분류 행과 화면에 표시된 상품 행들을 읽어
+   * window.__productList 배열에 누적 저장한다.
+   */
+  function collectVisibleProducts() {
+    const list = (window.__productList = window.__productList || []);
+
+    const midCodeCell = document.querySelector(
+      "div[id*='gdList.body'][id*='cell_'][id$='_0:text'].nexagridcellfocused, " +
+        "div[id*='gdList.body'][id*='cell_'][id$='_0:text'].nexagridselected"
+    );
+    const midCode = midCodeCell?.innerText?.trim() || '';
+
+    let midText = '';
+    if (midCodeCell) {
+      const nameId = midCodeCell.id.replace('_0:text', '_1:text');
+      const nameEl = document.getElementById(nameId);
+      midText = nameEl?.innerText?.trim() || '';
+    }
+
+    const rows = [
+      ...document.querySelectorAll(
+        "div[id*='gdDetail.body'][id*='cell_'][id$='_0:text']"
+      ),
+    ];
+
+    for (const codeEl of rows) {
+      const rowIndexMatch = codeEl.id.match(/cell_(\d+)_0:text$/);
+      if (!rowIndexMatch) continue;
+      const rowIdx = rowIndexMatch[1];
+
+      const getText = col =>
+        document.querySelector(
+          `div[id*='gdDetail.body'][id*='cell_${rowIdx}_${col}:text']`
+        )?.innerText?.trim() || '';
+
+      list.push({
+        midCode,
+        midText,
+        productCode: getText(0),
+        productName: getText(1),
+        sales: getText(2),
+        order: getText(3),
+        purchase: getText(4),
+        discard: getText(5),
+        stock: getText(6),
+      });
+    }
+  }
+
   async function autoClickAllProductCodes() {
     const seen = new Set();
     let scrollCount = 0;
@@ -41,6 +91,8 @@
         newCodes.push(code);
         console.log(`✅ 상품 클릭 완료: ${code}`);
         await delay(300);
+        // 화면에 표시된 상품 정보를 수집한다
+        collectVisibleProducts();
       }
 
       if (newCodes.length === 0) break;
@@ -98,6 +150,8 @@
     }
 
     console.log("🎉 전체 작업 완료: 중분류 수", seenMid.size);
+    // Python 측에서 읽을 수 있도록 전역 변수에 저장한다
+    window.__parsedData__ = window.__productList;
   }
 
   autoClickAllMidCodesAndProducts();


### PR DESCRIPTION
## Summary
- add `collectVisibleProducts` to gather mid-category and product data
- call `collectVisibleProducts` after each product click
- expose parsed data to Python at script end
- document new behaviour in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875aebe99b083208bdbc780a0390515