### PR TITLE
Add mid-category logging and tests

### DIFF
--- a/scripts/auto_collect_mid_products.js
+++ b/scripts/auto_collect_mid_products.js
@@ -1,4 +1,10 @@
 (() => {
+  window.__midCategoryLogs__ = [];
+  const origConsoleLog = console.log;
+  console.log = function (...args) {
+    window.__midCategoryLogs__.push(args.join(" "));
+    return origConsoleLog.apply(console, args);
+  };
   const delay = ms => new Promise(res => setTimeout(res, ms));
   const midCodeDataList = [];
 


### PR DESCRIPTION
## Summary
- keep console log messages in `window.__midCategoryLogs__` from the auto collect script
- print these logs in `main.py`
- test that log messages are returned by `main.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875e5b0a09c832098b5ad0c14a50edc