### PR TITLE
Fix ID extraction for Nexacro cells

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ if navigate_to_category_mix_ratio(driver):
     console.warn('⛔ 중분류 코드 셀 찾을 수 없음:', code);
     return false;
   }
-  const clickEl = document.getElementById(cell.id.replace(':text', ''));
+  const clickEl = document.getElementById(cell.id.split(':text')[0]);
   const rect = clickEl.getBoundingClientRect();
   ['mousedown', 'mouseup', 'click'].forEach(type =>
     clickEl.dispatchEvent(new MouseEvent(type, {

--- a/scripts/auto_collect_mid_products.js
+++ b/scripts/auto_collect_mid_products.js
@@ -86,7 +86,7 @@
         const midNameEl = document.querySelector(`div[id*='gdList.body'][id*='cell_${rowIdx}_1'][id$=':text']`);
         const midName = midNameEl?.innerText?.trim() || '';
 
-        const clickId = textEl.id.replace(":text", "");
+        const clickId = textEl.id.split(":text")[0];
         const clicked = await clickElementById(clickId);
         if (!clicked) {
           console.warn("❌ 중분류 클릭 실패 → ID:", clickId);


### PR DESCRIPTION
## Summary
- correct ID cleanup logic in auto_collect_mid_products.js
- update README example to use `split(':text')[0]`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875ebc28df48320a7398225f70bce96