### PR TITLE
Add load delay before entering category

### DIFF
--- a/analysis/navigation.py
+++ b/analysis/navigation.py
@@ -57,5 +57,8 @@ return true;
         log("nav", "ERROR", "❌ '중분류별 매출 구성비' 클릭 실패")
         return False
 
+    # 화면이 완전히 로드될 시간을 준다
+    time.sleep(1)
+
     log("nav", "SUCCESS", "✅ 메뉴 진입 완료")
     return True


### PR DESCRIPTION
## Summary
- wait a little after clicking the '중분류별 매출 구성비' menu

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875f44dcae08320b67e24e1872cd180