### PR TITLE
Improve error visibility when data is empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,13 @@ window.__MID_RANGE_START__ = "200";
 window.__MID_RANGE_END__ = "299";
 ```
 
+## 데이터가 수집되지 않을 때
+
+수집 스크립트 실행 후 `window.__parsedData__` 값이 비어 있다면
+브라우저 콘솔 로그를 확인해 보세요. `main.py`는 데이터가 없을 경우
+`driver.get_log("browser")` 결과와 `window.__parsedDataError__` 값을 출력하므로
+오류 메시지를 통해 문제 원인을 파악할 수 있습니다.
+
 ## JavaScript 자동 클릭 예시
 
 아래 코드는 중분류 코드와 상품코드를 순회하며 차례대로 클릭하는 간단한 스크립트입니다. 실행 후에는 수집된 결과를 `code_outputs/<YYYYMMDD>.txt` 파일에 저장하며, 같은 날짜의 파일이 이미 존재하면 덮어씁니다. 한 번의 실행 과정에서 만들어진 로그는 모두 누적하여 기록됩니다.

--- a/main.py
+++ b/main.py
@@ -150,6 +150,21 @@ def main() -> None:
         print(f"saved to {path}")
     else:
         print("no data found")
+        try:
+            error = driver.execute_script("return window.__parsedDataError__ || null")
+        except Exception:
+            error = None
+        if error:
+            print("스크립트 오류:", error)
+        try:
+            logs = driver.get_log("browser")
+        except Exception as e:
+            print(f"get_log failed: {e}")
+            logs = None
+        if logs:
+            print("브라우저 콘솔 로그:")
+            for entry in logs:
+                print(entry)
 
 
 if __name__ == "__main__":

--- a/scripts/auto_collect_mid_products.js
+++ b/scripts/auto_collect_mid_products.js
@@ -180,6 +180,7 @@
       await collectMidCodes();
     } catch (e) {
       console.warn(e);
+      window.__parsedDataError__ = e && e.message ? e.message : String(e);
     }
   })();
 })();

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -162,6 +162,7 @@ def test_save_to_txt_creates_parent_dir(tmp_path):
 
 def test_main_calls_navigation():
     driver = Mock()
+    driver.get_log = Mock(return_value=[])
 
     with (
         patch.object(main, "create_driver", return_value=driver),
@@ -175,6 +176,7 @@ def test_main_calls_navigation():
         main.main()
 
     nav.assert_called_once_with(driver)
+    driver.get_log.assert_called_once_with("browser")
 
 
 def test_run_script_collects_data(tmp_path):
@@ -224,6 +226,7 @@ def test_run_script_collects_data(tmp_path):
 
 def test_main_prints_mid_category_logs(capsys):
     driver = Mock()
+    driver.get_log = Mock(return_value=[])
 
     def exec_script(arg):
         if arg == "return window.__midCategoryLogs__ || []":
@@ -243,6 +246,7 @@ def test_main_prints_mid_category_logs(capsys):
         main.main()
 
     driver.execute_script.assert_any_call("return window.__midCategoryLogs__ || []")
+    driver.get_log.assert_called_once_with("browser")
     out = capsys.readouterr().out
     assert "중분류 클릭 로그" in out
     assert "['log1', 'log2']" in out


### PR DESCRIPTION
## Summary
- dump browser console logs on missing data
- expose script errors through `window.__parsedDataError__`
- document how to troubleshoot data collection issues
- test updated console log branch

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68760582530483209dcaf1c504892a17