### PR TITLE
Improve browser log handling

### DIFF
--- a/main.py
+++ b/main.py
@@ -13,6 +13,7 @@ from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
 
 from login.login_bgf import login_bgf
 from utils.popup_util import close_popups_after_delegate
+from utils.log_parser import extract_tab_lines
 from analysis import navigate_to_category_mix_ratio
 
 SCRIPT_DIR = Path(__file__).with_name("scripts")
@@ -162,9 +163,15 @@ def main() -> None:
             print(f"get_log failed: {e}")
             logs = None
         if logs:
-            print("브라우저 콘솔 로그:")
-            for entry in logs:
-                print(entry)
+            lines = extract_tab_lines(logs)
+            if lines:
+                print("추출된 로그 데이터:")
+                for line in lines:
+                    print(line)
+            else:
+                print("브라우저 콘솔 로그:")
+                for entry in logs:
+                    print(entry)
 
 
 if __name__ == "__main__":

--- a/tests/test_log_parser.py
+++ b/tests/test_log_parser.py
@@ -1,0 +1,15 @@
+import importlib.util
+import pathlib
+
+_spec = importlib.util.spec_from_file_location(
+    "log_parser", pathlib.Path(__file__).resolve().parents[1] / "utils" / "log_parser.py"
+)
+log_parser = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(log_parser)
+
+
+def test_extract_tab_lines_parses_quote_escaped_tabs():
+    logs = [{"message": 'prefix "001\t33\t8800\tname\t1\t1\t\t\t0" suffix'}]
+    result = log_parser.extract_tab_lines(logs)
+    assert result == ["001\t33\t8800\tname\t1\t1\t\t\t0"]
+

--- a/utils/log_parser.py
+++ b/utils/log_parser.py
@@ -1,0 +1,21 @@
+import re
+from typing import Iterable
+
+
+def extract_tab_lines(logs: Iterable[dict]) -> list[str]:
+    """Return log messages containing tab-separated text.
+
+    Chrome 로그 메시지 형식에서 따옴표 내부의 내용을 추출해 ``\t`` 문자열을
+    실제 탭 문자로 변환한다.
+    """
+    result: list[str] = []
+    for entry in logs:
+        msg = entry.get("message", "") if isinstance(entry, dict) else str(entry)
+        # 따옴표 안에 \t 또는 실제 탭 문자가 포함된 패턴을 찾는다.
+        m = re.search(r'"([^"\n]*(?:\\t|\t)[^"\n]*)"', msg)
+        if m:
+            text = m.group(1).replace("\\t", "\t")
+            result.append(text)
+        elif "\\t" in msg or "\t" in msg:
+            result.append(msg.replace("\\t", "\t"))
+    return result


### PR DESCRIPTION
## Summary
- add a helper to parse tab-separated console logs
- integrate parser in main fallback logging
- test the new parser

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687608c2d7a083209050592b38ca1a82