### PR TITLE
Add mid code/name to listener output

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,12 @@ python -m aaa  # 또는 python main.py
 같은 날짜의 파일이 이미 존재하면 처음 시작 시 한 번만 삭제 후 새로 생성하며,
 이후에는 이벤트가 발생할 때마다 중복되지 않는 새 라인만 이어서 기록합니다.
 
+각 줄은 다음 순서의 필드가 탭 문자로 구분되어 저장됩니다.
+
+```
+midCode    midName    productCode    productName    sales    order    purchase    discard    stock
+```
+
 웹 브라우저에서 바로 파일을 받고 싶다면 기존 `download_with_blob.js` 를 사용할 수 있으나,
 통합 스크립트만으로도 데이터를 얻을 수 있으므로 선택 사항입니다.
 

--- a/main.py
+++ b/main.py
@@ -31,6 +31,7 @@ def get_script_files() -> list[str]:
 # code_outputs/날짜.txt 필드 저장 순서를 지정한다.
 FIELD_ORDER = [
     "midCode",
+    "midName",
     "productCode",
     "productName",
     "sales",

--- a/scripts/data_collect_listener.js
+++ b/scripts/data_collect_listener.js
@@ -2,6 +2,9 @@
   window.__liveData__ = window.__liveData__ || [];
   const seen = new Set(window.__liveData__);
 
+  let currentMidCode = '';
+  let currentMidName = '';
+
   function getText(row, col) {
     const el = document.querySelector(
       `div[id*='gdDetail.body'][id*='cell_${row}_${col}'][id$=':text']`
@@ -20,6 +23,8 @@
       const row = el.id.match(/cell_(\d+)_0:text/)?.[1];
       if (!row) continue;
       const line = [
+        currentMidCode || '0',
+        currentMidName || '',
         getText(row, 0) || '0',
         getText(row, 1) || '0',
         getText(row, 2) || '0',
@@ -39,6 +44,10 @@
     }
   }
 
-  document.addEventListener('mid-clicked', () => setTimeout(collectLines, 100));
+  document.addEventListener('mid-clicked', event => {
+    currentMidCode = event.detail?.code || '';
+    currentMidName = event.detail?.midName || '';
+    setTimeout(collectLines, 100);
+  });
   document.addEventListener('product-scroll', () => setTimeout(collectLines, 100));
 })();

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -112,6 +112,7 @@ def test_save_to_txt_writes_to_date_file(tmp_path):
     data = [
         {
             "midCode": "1",
+            "midName": "m",
             "productCode": "2",
             "productName": "a",
             "sales": 3,
@@ -137,6 +138,7 @@ def test_save_to_txt_field_order(tmp_path):
     data = [
         {
             "midCode": "001",
+            "midName": "abc-mid",
             "productCode": "123",
             "productName": "abc",
             "sales": 1,
@@ -189,6 +191,7 @@ def test_run_script_collects_data(tmp_path):
     expected = [
         {
             "midCode": "1",
+            "midName": "m",
             "productCode": "2",
             "productName": "a",
             "sales": 3,


### PR DESCRIPTION
## 요약
- 중분류 클릭 정보를 전역 변수로 저장하고 listener에서 사용
- FIELD_ORDER에 midName 추가
- 테스트 수정 및 README에 새로운 출력 형식 설명

## 테스트
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68762ac44c50832080f2cd8beff44b62