### PR TITLE
Fix midName extraction method

### DIFF
--- a/scripts/auto_collect_mid_products.js
+++ b/scripts/auto_collect_mid_products.js
@@ -139,8 +139,8 @@
         if (!/^\d{3}$/.test(code) || seenMid.has(code)) continue;
         if ((startCode && code < startCode) || (endCode && code > endCode)) continue;
 
-        const rowIdx = textEl.id.match(/cell_(\d+)_0:text/)?.[1];
-        const midNameEl = document.querySelector(`div[id*='gdList.body'][id*='cell_${rowIdx}_1'][id$=':text']`);
+        const row = textEl.closest("div[id*='gdList.body'][id*='row_']");
+        const midNameEl = row?.querySelector("div[id$='_1:text']");
         const midName = midNameEl?.innerText?.trim() || '';
 
         const clickId = textEl.id.split(":text")[0];


### PR DESCRIPTION
## Summary
- obtain midName relative to clicked mid code row

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68762e9bccfc8320b19eb80af666d280