### PR TITLE
Add mid_excel export

### DIFF
--- a/main.py
+++ b/main.py
@@ -14,7 +14,7 @@ from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
 from login.login_bgf import login_bgf
 from utils.popup_util import close_popups_after_delegate
 from utils.log_parser import extract_tab_lines
-from utils import append_unique_lines
+from utils import append_unique_lines, convert_txt_to_excel
 
 SCRIPT_DIR = Path(__file__).with_name("scripts")
 CODE_OUTPUT_DIR = Path(__file__).with_name("code_outputs")
@@ -146,7 +146,8 @@ def main() -> None:
 
 
     # 중분류 매출 구성비 화면 진입 후 자동 수집 스크립트를 실행한다
-    output_path = CODE_OUTPUT_DIR / (datetime.now().strftime("%Y%m%d") + ".txt")
+    date_str = datetime.now().strftime("%y%m%d")
+    output_path = CODE_OUTPUT_DIR / f"{date_str}.txt"
     if output_path.exists():
         output_path.unlink()
 
@@ -171,6 +172,16 @@ def main() -> None:
         time.sleep(0.5)
 
     print(f"saved to {output_path}")
+    time.sleep(3)
+    excel_dir = CODE_OUTPUT_DIR / "mid_excel"
+    excel_dir.mkdir(parents=True, exist_ok=True)
+    excel_path = excel_dir / f"{date_str}.xlsx"
+
+    try:
+        convert_txt_to_excel(str(output_path), str(excel_path))
+        print(f"converted to {excel_path}")
+    except Exception as e:
+        print(f"excel conversion failed: {e}")
 
     error = None
     try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pandas
+openpyxl

--- a/tests/test_convert_txt_to_excel.py
+++ b/tests/test_convert_txt_to_excel.py
@@ -1,0 +1,34 @@
+import importlib.util
+import pathlib
+import pandas as pd
+
+_spec = importlib.util.spec_from_file_location(
+    "convert_txt_to_excel",
+    pathlib.Path(__file__).resolve().parents[1] / "utils" / "convert_txt_to_excel.py",
+)
+convert_module = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(convert_module)
+
+
+def test_convert_txt_to_excel(tmp_path):
+    txt = tmp_path / "sample.txt"
+    txt.write_text("001|mid|111|prod|1|2|3|4|5\n", encoding="utf-8")
+
+    out_file = tmp_path / "out.xlsx"
+    out_path = convert_module.convert_txt_to_excel(str(txt), str(out_file))
+    assert out_path.exists()
+
+    df = pd.read_excel(out_path)
+    assert list(df.columns) == [
+        "중분류코드",
+        "중분류명",
+        "상품코드",
+        "상품명",
+        "매출",
+        "발주",
+        "매입",
+        "폐기",
+        "현재고",
+    ]
+    assert df.iloc[0].tolist() == [1, "mid", 111, "prod", 1, 2, 3, 4, 5]
+

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -254,3 +254,30 @@ def test_main_prints_mid_category_logs(capsys):
     out = capsys.readouterr().out
     assert "중분류 클릭 로그" in out
     assert "['log1', 'log2']" in out
+
+
+def test_main_converts_txt_to_excel(tmp_path):
+    driver = Mock()
+    driver.get_log = Mock(return_value=[])
+
+    date_str = datetime.now().strftime("%y%m%d")
+    out_dir = tmp_path / "code_outputs"
+
+    with (
+        patch.object(main, "CODE_OUTPUT_DIR", out_dir),
+        patch.object(main, "create_driver", return_value=driver),
+        patch.object(main, "login_bgf", return_value=True),
+        patch.object(main, "close_popups_after_delegate"),
+        patch.object(main, "wait_for_mix_ratio_page", return_value=True),
+        patch.object(main, "run_script"),
+        patch.object(main, "wait_for_data", return_value=None),
+        patch.object(main, "append_unique_lines", return_value=0),
+        patch.object(main, "convert_txt_to_excel") as convert_mock,
+        patch.object(main.time, "sleep"),
+    ):
+        driver.execute_script.side_effect = [[], [], {}, None]
+        main.main()
+
+    expected_txt = out_dir / f"{date_str}.txt"
+    expected_excel = out_dir / "mid_excel" / f"{date_str}.xlsx"
+    convert_mock.assert_called_once_with(str(expected_txt), str(expected_excel))

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,2 +1,5 @@
 """Utility package."""
 from .file_util import append_unique_lines
+from .convert_txt_to_excel import convert_txt_to_excel
+
+__all__ = ["append_unique_lines", "convert_txt_to_excel"]

--- a/utils/convert_txt_to_excel.py
+++ b/utils/convert_txt_to_excel.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+import pandas as pd
+
+
+def convert_txt_to_excel(
+    txt_path: str, output_path: str | Path | None = None, encoding: str = "utf-8"
+) -> Path:
+    """Convert a pipe-delimited text file to an Excel file with one sheet.
+
+    Parameters
+    ----------
+    txt_path: str
+        Path to the input text file.
+    output_path: str | Path | None, optional
+        Destination Excel file path. If omitted, a file named
+        ``매출분석_YYYYMMDD.xlsx`` is created next to ``txt_path``.
+    encoding: str, default "utf-8"
+        Encoding of the text file.
+
+    Returns
+    -------
+    Path
+        Path to the generated Excel file.
+    """
+    txt_path = Path(txt_path)
+    df = pd.read_csv(txt_path, sep="|", header=None, encoding=encoding)
+    df.columns = [
+        "중분류코드",
+        "중분류명",
+        "상품코드",
+        "상품명",
+        "매출",
+        "발주",
+        "매입",
+        "폐기",
+        "현재고",
+    ]
+    if output_path is None:
+        out_name = datetime.now().strftime("매출분석_%Y%m%d.xlsx")
+        output_path = txt_path.with_name(out_name)
+    else:
+        output_path = Path(output_path)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    df.to_excel(output_path, index=False)
+    return Path(output_path)


### PR DESCRIPTION
## Summary
- move txt output to `code_outputs` root and generate excel under `mid_excel`
- allow specifying Excel path in `convert_txt_to_excel`
- test excel converter with explicit output path
- ensure main waits and converts saved txt file

## Testing
- `pip install -q pandas openpyxl`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68771e8076e48320b9e94c7913853444