### PR TITLE
Fix txt-to-excel delimiter

### DIFF
--- a/tests/test_convert_txt_to_excel.py
+++ b/tests/test_convert_txt_to_excel.py
@@ -12,7 +12,7 @@ _spec.loader.exec_module(convert_module)
 
 def test_convert_txt_to_excel(tmp_path):
     txt = tmp_path / "sample.txt"
-    txt.write_text("001|mid|111|prod|1|2|3|4|5\n", encoding="utf-8")
+    txt.write_text("001\tmid\t111\tprod\t1\t2\t3\t4\t5\n", encoding="utf-8")
 
     out_file = tmp_path / "out.xlsx"
     out_path = convert_module.convert_txt_to_excel(str(txt), str(out_file))

--- a/utils/convert_txt_to_excel.py
+++ b/utils/convert_txt_to_excel.py
@@ -26,7 +26,7 @@ def convert_txt_to_excel(
         Path to the generated Excel file.
     """
     txt_path = Path(txt_path)
-    df = pd.read_csv(txt_path, sep="|", header=None, encoding=encoding)
+    df = pd.read_csv(txt_path, sep="\t", header=None, encoding=encoding)
     df.columns = [
         "중분류코드",
         "중분류명",


### PR DESCRIPTION
## Summary
- update `convert_txt_to_excel` to read tab-separated files
- adjust test to match new delimiter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687733da1a4c832087ea3afb86c14372