### PR TITLE
Fix Excel text export

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pandas
 openpyxl
+XlsxWriter

--- a/tests/test_convert_txt_to_excel.py
+++ b/tests/test_convert_txt_to_excel.py
@@ -18,7 +18,7 @@ def test_convert_txt_to_excel(tmp_path):
     out_path = convert_module.convert_txt_to_excel(str(txt), str(out_file))
     assert out_path.exists()
 
-    df = pd.read_excel(out_path)
+    df = pd.read_excel(out_path, dtype=str)
     assert list(df.columns) == [
         "중분류코드",
         "중분류명",
@@ -30,5 +30,15 @@ def test_convert_txt_to_excel(tmp_path):
         "폐기",
         "현재고",
     ]
-    assert df.iloc[0].tolist() == [1, "mid", 111, "prod", 1, 2, 3, 4, 5]
+    assert df.iloc[0].tolist() == [
+        "001",
+        "mid",
+        "111",
+        "prod",
+        "1",
+        "2",
+        "3",
+        "4",
+        "5",
+    ]
 

--- a/utils/convert_txt_to_excel.py
+++ b/utils/convert_txt_to_excel.py
@@ -37,7 +37,13 @@ def convert_txt_to_excel(
     txt_path = Path(txt_path)
     log("convert", "INFO", f"텍스트 파일 읽기 시도: {txt_path}")
     try:
-        df = pd.read_csv(txt_path, sep="\t", header=None, encoding=encoding)
+        df = pd.read_csv(
+            txt_path,
+            sep="\t",
+            header=None,
+            dtype=str,
+            encoding=encoding,
+        )
     except Exception as e:
         log("convert", "ERROR", f"텍스트 파일 읽기 실패: {e}")
         raise
@@ -54,6 +60,9 @@ def convert_txt_to_excel(
         "폐기",
         "현재고",
     ]
+
+    for col in ["매출", "발주", "매입", "폐기", "현재고"]:
+        df[col] = pd.to_numeric(df[col], errors="coerce")
     if output_path is None:
         out_name = datetime.now().strftime("매출분석_%Y%m%d.xlsx")
         output_path = txt_path.with_name(out_name)
@@ -63,7 +72,12 @@ def convert_txt_to_excel(
 
     log("convert", "INFO", f"엑셀 파일 저장 위치: {output_path}")
     try:
-        df.to_excel(output_path, index=False)
+        with pd.ExcelWriter(
+            output_path,
+            engine="xlsxwriter",
+            engine_kwargs={"options": {"strings_to_numbers": False}},
+        ) as writer:
+            df.to_excel(writer, index=False)
     except Exception as e:
         log("convert", "ERROR", f"엑셀 저장 실패: {e}")
         raise


### PR DESCRIPTION
## Summary
- keep category and product codes as strings when saving
- adjust test to expect string columns
- add `XlsxWriter` dependency for Excel export

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687748f5fef083209d8f852bb3b53c9a