### PR TITLE
Add DB saving step after data collection

### DIFF
--- a/main.py
+++ b/main.py
@@ -15,6 +15,7 @@ from login.login_bgf import login_bgf
 from utils.popup_util import close_popups_after_delegate
 from utils.log_parser import extract_tab_lines
 from utils import append_unique_lines, convert_txt_to_excel
+from utils.db_util import write_sales_data
 
 SCRIPT_DIR = Path(__file__).with_name("scripts")
 CODE_OUTPUT_DIR = Path(__file__).with_name("code_outputs")
@@ -170,6 +171,13 @@ def main() -> None:
         if parsed is not None:
             break
         time.sleep(0.5)
+
+    db_path = CODE_OUTPUT_DIR / f"{datetime.now():%Y%m%d}.db"
+    try:
+        inserted = write_sales_data(parsed, db_path)
+        print(f"db saved to {db_path}, inserted {inserted} rows")
+    except Exception as e:
+        print(f"db write failed: {e}")
 
     print(f"saved to {output_path}")
     time.sleep(3)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -281,3 +281,30 @@ def test_main_converts_txt_to_excel(tmp_path):
     expected_txt = out_dir / f"{date_str}.txt"
     expected_excel = out_dir / "mid_excel" / f"{date_str}.xlsx"
     convert_mock.assert_called_once_with(str(expected_txt), str(expected_excel))
+
+
+def test_main_writes_sales_data(tmp_path):
+    driver = Mock()
+    driver.get_log = Mock(return_value=[])
+
+    out_dir = tmp_path / "code_outputs"
+    parsed = [{"x": 1}]
+
+    with (
+        patch.object(main, "CODE_OUTPUT_DIR", out_dir),
+        patch.object(main, "create_driver", return_value=driver),
+        patch.object(main, "login_bgf", return_value=True),
+        patch.object(main, "close_popups_after_delegate"),
+        patch.object(main, "wait_for_mix_ratio_page", return_value=True),
+        patch.object(main, "run_script"),
+        patch.object(main, "wait_for_data", return_value=None),
+        patch.object(main, "append_unique_lines", return_value=0),
+        patch.object(main, "convert_txt_to_excel"),
+        patch.object(main.time, "sleep"),
+        patch.object(main, "write_sales_data") as write_mock,
+    ):
+        driver.execute_script.side_effect = [[], [], parsed, None]
+        main.main()
+
+    db_path = out_dir / f"{datetime.now():%Y%m%d}.db"
+    write_mock.assert_called_once_with(parsed, db_path)


### PR DESCRIPTION
## Summary
- save parsed sales data into sqlite DB once data collection ends
- log DB insertion result in `main.py`
- test DB write by patching `write_sales_data`

## Testing
- `pytest tests/test_main.py::test_main_writes_sales_data -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687893d1592083209b7de8c58d5d865f