### PR TITLE
Add text file parser

### DIFF
--- a/tests/test_txt_parser.py
+++ b/tests/test_txt_parser.py
@@ -1,0 +1,37 @@
+import importlib.util
+import pathlib
+
+_spec = importlib.util.spec_from_file_location(
+    "txt_parser",
+    pathlib.Path(__file__).resolve().parents[1] / "utils" / "txt_parser.py",
+)
+txt_parser = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(txt_parser)
+
+
+def test_parse_txt_basic(tmp_path):
+    txt = tmp_path / "sample.txt"
+    txt.write_text("001\tmid\t111\tprod\t5\t1\t2\t3\t4\n", encoding="utf-8")
+    records = txt_parser.parse_txt(txt)
+    assert records == [
+        {
+            "midCode": "001",
+            "midName": "mid",
+            "productCode": "111",
+            "productName": "prod",
+            "sales": 5,
+            "order": 1,
+            "purchase": 2,
+            "discard": 3,
+            "stock": 4,
+        }
+    ]
+
+
+def test_parse_txt_handles_missing_values(tmp_path):
+    txt = tmp_path / "sample.txt"
+    txt.write_text("001\tmid\t111\tprod\t5\t1\t2\t-\t\n", encoding="utf-8")
+    records = txt_parser.parse_txt(txt)
+    rec = records[0]
+    assert rec["discard"] == 0
+    assert rec["stock"] == 0

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -2,10 +2,12 @@
 from .file_util import append_unique_lines
 from .convert_txt_to_excel import convert_txt_to_excel
 from .db_util import init_db, write_sales_data
+from .txt_parser import parse_txt
 
 __all__ = [
     "append_unique_lines",
     "convert_txt_to_excel",
     "init_db",
     "write_sales_data",
+    "parse_txt",
 ]

--- a/utils/txt_parser.py
+++ b/utils/txt_parser.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+
+FIELD_ORDER = [
+    "midCode",
+    "midName",
+    "productCode",
+    "productName",
+    "sales",
+    "order",
+    "purchase",
+    "discard",
+    "stock",
+]
+
+
+def _to_int(value: str) -> int:
+    try:
+        return int(str(value).replace(",", ""))
+    except Exception:
+        try:
+            return int(float(value))
+        except Exception:
+            return 0
+
+
+def parse_txt(path: str | Path, encoding: str = "utf-8") -> list[dict[str, Any]]:
+    """Parse a tab-delimited text file into a list of record dicts."""
+    path = Path(path)
+    records: list[dict[str, Any]] = []
+    with path.open("r", encoding=encoding) as f:
+        for line in f:
+            text = line.rstrip("\n")
+            if not text:
+                continue
+            parts = text.split("\t")
+            if len(parts) < len(FIELD_ORDER):
+                parts += ["" for _ in range(len(FIELD_ORDER) - len(parts))]
+            record = dict(zip(FIELD_ORDER, parts[: len(FIELD_ORDER)]))
+            for key in ["sales", "order", "purchase", "discard", "stock"]:
+                record[key] = _to_int(record.get(key, "0"))
+            records.append(record)
+    return records


### PR DESCRIPTION
## Summary
- add `parse_txt` utility to convert tab-separated files to records
- expose `parse_txt` in `utils.__init__`
- test parsing behavior

## Testing
- `pytest -q tests/test_txt_parser.py tests/test_db_util.py`
- `pytest -q tests/test_main.py::test_main_writes_sales_data`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68799e56a13483209d2f09bf1107f36a