### PR TITLE
Add CLI invocation guard and subprocess test

### DIFF
--- a/tests/test_popup_util.py
+++ b/tests/test_popup_util.py
@@ -72,7 +72,9 @@ _spec = importlib.util.spec_from_file_location(
     pathlib.Path(__file__).resolve().parents[1] / "utils" / "popup_util.py",
 )
 popup_util = importlib.util.module_from_spec(_spec)
-sys.modules.setdefault("utils", types.ModuleType("utils"))
+utils_pkg = types.ModuleType("utils")
+utils_pkg.__path__ = [str(pathlib.Path(__file__).resolve().parents[1] / "utils")]
+sys.modules["utils"] = utils_pkg
 _spec.loader.exec_module(popup_util)
 
 


### PR DESCRIPTION
## Summary
- ensure `main()` runs when executing `python main.py`
- allow `_process_and_save_data` to handle list-of-dict inputs and convert daily DB name
- output mid category logs and convert text to Excel each cycle
- add subprocess-based CLI test and fix module stubs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c64c30b088320a5587061e6bf5e61