### PR TITLE
Add global automation trigger for mid/product collection

### DIFF
--- a/scripts/auto_collect_mid_products.js
+++ b/scripts/auto_collect_mid_products.js
@@ -4,7 +4,13 @@
     parsedData: null,
     error: null
   };
+  async function autoClickAllMidCodesAndProducts(startCode = null, endCode = null) {
+    await waitForMidGrid();
+    await collectMidCodes(startCode, endCode);
+  }
+
   window.collectMidProducts = collectMidCodes;
+  window.automation.autoClickAllMidCodesAndProducts = autoClickAllMidCodesAndProducts;
   const origConsoleLog = console.log;
   console.log = function (...args) {
     window.automation.logs.push(args.join(" "));


### PR DESCRIPTION
## Summary
- expose a new function `autoClickAllMidCodesAndProducts` inside `auto_collect_mid_products.js`
- attach the function to `window.automation` for reuse

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c77cf094883208bde6a086f2f2fae