### PR TITLE
Update logger usage in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@
 ```python
 from selenium.webdriver.remote.webdriver import WebDriver
 from main import run_script, wait_for_mix_ratio_page, NAVIGATION_SCRIPT
-from utils.log_util import create_logger
+from utils.log_util import get_logger
 import time
 
-log = create_logger("example")
+log = get_logger("example")
 
 # 로그 파일은 매 실행 시 덮어쓰며 logs/\<YYYYMMDD\>.log 형태로 저장됩니다.
 


### PR DESCRIPTION
## Summary
- use `get_logger` instead of deprecated `create_logger` in README example

## Testing
- `pytest -q` *(fails: convert_txt_to_excel.py, file_util.py missing)*

------
https://chatgpt.com/codex/tasks/task_e_687db7390798832088dcafa1ae1f5d8d