### PR TITLE
Fix past 7-day collection bug

### DIFF
--- a/main.py
+++ b/main.py
@@ -347,6 +347,8 @@ def _run_collection_cycle() -> None:
                 
                 past_dates = get_past_dates(7)
                 for date_str in past_dates:
+                    # Ensure required automation functions remain available
+                    run_script(driver, DEFAULT_SCRIPT)
                     log.info(f"-------------------- 과거 데이터 수집 중: {date_str} --------------------", extra={'tag': '7day_collection'})
                     try:
                         result = execute_collect_single_day_data(driver, date_str)


### PR DESCRIPTION
## Summary
- reload the mid product automation script for each date

## Testing
- `pytest tests/test_convert_txt_to_excel.py::test_convert_txt_to_excel -q`
- `pytest -q` *(fails: js_util module missing execute_collect_past7days and more)*

------
https://chatgpt.com/codex/tasks/task_e_687dc4b5da7c832097c0cc9af8096baf