### PR TITLE
Improve data format docs and add key validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,24 @@ python main.py
 - `nexacro_automation_library.js`를 브라우저에 주입하고, `window.automation.runCollectionForDate('YYYYMMDD')` 함수를 호출하여 데이터 수집을 시작합니다.
 - 수집된 데이터는 통합 DB에 저장됩니다.
 
+## 데이터 포맷
+
+JavaScript 스크립트에서 수집한 각 상품 데이터는 다음과 같은 필드를 포함한 객체 형태로 Python에 전달됩니다.
+
+| 키 이름        | 설명             |
+|----------------|------------------|
+| `midCode`      | 중분류 코드      |
+| `midName`      | 중분류명         |
+| `productCode`  | 상품 코드        |
+| `productName`  | 상품명           |
+| `sales`        | 매출액           |
+| `order_cnt`    | 주문수량         |
+| `purchase`     | 매입액           |
+| `disposal`     | 폐기액           |
+| `stock`        | 재고액           |
+
+`write_sales_data` 함수는 위 필드명 외에도 `snake_case` 형태(`mid_code` 등)나 기존 텍스트 파일 포맷(`order`, `discard`)을 허용합니다.
+
 ## 데이터베이스 구조
 
 `mid_sales` 테이블에 데이터가 저장되며, 중복 저장을 방지하기 위한 제약 조건이 포함되어 있습니다.

--- a/utils/db_util.py
+++ b/utils/db_util.py
@@ -25,6 +25,33 @@ else:  # pragma: no cover - fallback when executed directly
 log = get_logger(__name__)
 
 
+# ``write_sales_data`` 함수에서 허용하는 키 목록
+ALLOWED_KEYS: set[str] = {
+    "midCode",
+    "midName",
+    "productCode",
+    "productName",
+    "sales",
+    "order",
+    "order_cnt",
+    "purchase",
+    "disposal",
+    "discard",
+    "stock",
+    # snake_case 변형
+    "mid_code",
+    "mid_name",
+    "product_code",
+    "product_name",
+    # 원본 데이터셋 컬럼명
+    "SALE_QTY",
+    "ORD_QTY",
+    "BUY_QTY",
+    "DISUSE_QTY",
+    "STOCK_QTY",
+}
+
+
 # 통합 매출 데이터 테이블 스키마
 CREATE_TABLE_SQL = """
 CREATE TABLE IF NOT EXISTS mid_sales (
@@ -114,6 +141,12 @@ def write_sales_data(records: list[dict[str, Any]], db_path: Path, collected_at_
     """
 
     for rec in records:
+        unknown = set(rec) - ALLOWED_KEYS
+        if unknown:
+            log.warning(
+                f"Unexpected keys in record ignored: {sorted(unknown)}",
+                extra={"tag": "db"},
+            )
         product_code = _get_value(rec, "productCode", "product_code")
         sales_raw = _get_value(rec, "sales", "SALE_QTY")
 


### PR DESCRIPTION
## Summary
- describe the expected JS-to-Python data format in the README
- clarify allowed fields for `write_sales_data` and warn when unknown keys are passed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68844cec3be48320813508e795fe743e