### PR TITLE
Fix automation script scoping

### DIFF
--- a/scripts/index.js
+++ b/scripts/index.js
@@ -216,6 +216,7 @@
     ensureMainFormLoaded,
     parseDetailDataset,
     parseListDataset,
+    clickElementById,
   } = window.automationHelpers;
 
   async function collectProducts(midCode, midName) {
@@ -296,6 +297,7 @@
     }finally{
       window.automation.isCollecting=false;
     }
+  }
 
   async function verifyMidSaleQty(midInfo){
     if(!window.automation.parsedData) return false;


### PR DESCRIPTION
## Summary
- include clickElementById helper in automation core
- close runCollectionForDate scope so verification functions are separate

## Testing
- `pytest -q` *(fails: AttributeError and assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_6888274c4f0483209e0b595b1b6e8dde