### PR TITLE
Fix script init order

### DIFF
--- a/login/login_bgf.py
+++ b/login/login_bgf.py
@@ -44,24 +44,9 @@ def load_credentials(path: str | None = None) -> dict:
     Otherwise, it loads credentials from environment variables, which can be
     populated from a .env file.
     """
-    # 항상 프로젝트 루트의 .env 파일을 먼저 로드 시도
-    project_root_env = ROOT_DIR / ".env"
-    if project_root_env.exists():
-        log.debug(
-            f"Attempting to load .env from Project Root: {project_root_env}",
-            extra={"tag": "env"},
-        )
-        # override=True로 하여 환경 변수 우선 적용
-        load_dotenv(dotenv_path=project_root_env, override=True)
-    else:
-        log.warning(
-            f"Project Root .env not found: {project_root_env}",
-            extra={"tag": "env"},
-        )
-
-    # 현재 작업 디렉토리의 .env 파일이 존재하고 프로젝트 루트와 다르면 추가로 로드 시도
+    # 현재 작업 디렉터리의 ``.env`` 파일을 먼저 시도한다
     cwd_env = Path.cwd() / ".env"
-    if cwd_env.exists() and cwd_env != project_root_env:
+    if cwd_env.exists():
         log.debug(
             f"Attempting to load .env from CWD: {cwd_env}",
             extra={"tag": "env"},

--- a/main.py
+++ b/main.py
@@ -13,6 +13,7 @@ from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.common.by import By
 from login.login_bgf import login_bgf
+from dotenv import load_dotenv
 from selenium.webdriver.chrome.options import Options
 from webdriver_manager.chrome import ChromeDriverManager
 from selenium.webdriver.chrome.service import Service
@@ -115,16 +116,23 @@ def main() -> None:
     print("Starting BGF Retail Automation...")
     driver = None
     try:
+        # Load environment variables from project root if available
+        load_dotenv(SCRIPT_DIR / ".env", override=False)
+
         driver = create_driver()
         if not login_bgf(driver, credential_path=None):
             return
 
-        # Load default script (index.js) to initialize window.automation
+        # Load helper scripts before the main automation script
         import json
 
         with open(SCRIPT_DIR / "config.json", "r", encoding="utf-8") as f:
             config = json.load(f)
         default_script = config["scripts"]["default"]
+
+        # ``nexacro_helpers.js`` defines the ``window.automationHelpers`` object
+        # used by ``index.js``. It must be loaded first.
+        run_script(driver, "scripts/nexacro_helpers.js")
         run_script(driver, f"scripts/{default_script}")
 
         run_script(driver, NAVIGATION_SCRIPT)


### PR DESCRIPTION
## Summary
- load environment variables for automation at startup
- execute `nexacro_helpers.js` before `index.js`
- simplify credential loader

## Testing
- `pytest tests/test_login.py -q`
- `pytest -q` *(fails: module 'main' has no attribute 'wait_for_data', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68884666e6c08320be6403a4ef6300b9