### PR TITLE
Fix env debug log format

### DIFF
--- a/login/login_bgf.py
+++ b/login/login_bgf.py
@@ -54,13 +54,11 @@ def load_credentials(path: str | None = None) -> dict:
         load_dotenv(dotenv_path=cwd_env, override=False)
 
     log.debug(
-        f"BGF_USER_ID after load_dotenv: {
-            os.environ.get('BGF_USER_ID')}",
+        f"BGF_USER_ID after load_dotenv: {os.environ.get('BGF_USER_ID')}",
         extra={"tag": "env"},
     )
     log.debug(
-        f"BGF_PASSWORD after load_dotenv: {
-            os.environ.get('BGF_PASSWORD')}",
+        f"BGF_PASSWORD after load_dotenv: {os.environ.get('BGF_PASSWORD')}",
         extra={"tag": "env"},
     )
 


### PR DESCRIPTION
## Summary
- `.env` 로드 후 환경 변수를 출력할 때 f-string 형식을 수정했습니다.

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68888fb0173c83208815184b8be31457