### PR TITLE
Update default JS script

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,7 +1,7 @@
 {
     "db_file": "code_outputs/integrated_sales.db",
     "scripts": {
-        "default": "index.js",
+        "default": "nexacro_automation_library.js",
         "listener": "data_collect_listener.js",
         "navigation": "navigation.js"
     },

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,6 +7,6 @@ def test_default_script_name():
     )
     config = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(config)
-    assert config.DEFAULT_SCRIPT == "index.js"
-    assert config.config["scripts"]["default"] == "index.js"
+    assert config.DEFAULT_SCRIPT == "nexacro_automation_library.js"
+    assert config.config["scripts"]["default"] == "nexacro_automation_library.js"
 


### PR DESCRIPTION
## Summary
- update the default script path in `config.json`
- fix related tests expecting the new default script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688892474ec083209640efeb822a1b89