### PR TITLE
Update README to reflect current automation scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@
 {
     "db_file": "code_outputs/integrated_sales.db",
     "scripts": {
-        "automation_library": "index.js",
+        "default": "nexacro_automation_library.js",
+        "listener": "data_collect_listener.js",
         "navigation": "navigation.js"
     },
     "field_order": [
@@ -31,14 +32,18 @@
         "sales", "order_cnt", "purchase", "disposal", "stock"
     ],
     "timeouts": {
+        "data_collection": 300,
         "page_load": 120
-    }
+    },
+    "cycle_interval_seconds": 60,
+    "log_file": "logs/automation.log"
 }
 ```
 
 - `db_file`: 모든 데이터가 저장될 통합 SQLite DB 파일 경로입니다.
 - `scripts`: 자동화에 사용될 JavaScript 파일 목록입니다.
-  - `automation_library`: 핵심 데이터 수집 로직이 담긴 Nexacro 최적화 라이브러리입니다.
+  - `default`: 핵심 데이터 수집 로직이 담긴 Nexacro 최적화 라이브러리입니다.
+  - `listener`: 실시간 DOM 변화를 감지하여 데이터를 수집하는 스크립트입니다.
   - `navigation`: 목표 페이지로 이동하는 스크립트입니다.
 
 ### 2. 로그인 정보
@@ -70,7 +75,7 @@ python main.py
 각 수집 사이클(`_run_collection_cycle`)은 다음처럼 동작합니다.
 - Chrome 드라이버를 실행하고 로그인합니다.
 - `navigation.js`를 실행하여 목표 페이지로 이동합니다.
-- `index.js`를 브라우저에 주입하고, `window.automation.runCollectionForDate('YYYYMMDD')` 함수를 호출하여 데이터 수집을 시작합니다.
+- `nexacro_automation_library.js`를 브라우저에 주입하고, `window.automation.runCollectionForDate('YYYYMMDD')` 함수를 호출하여 데이터 수집을 시작합니다.
 - 수집된 데이터는 통합 DB에 저장됩니다.
 
 ## 데이터 포맷
@@ -112,7 +117,7 @@ CREATE TABLE IF NOT EXISTS mid_sales (
 );
 ```
 
-## 자동화 스크립트 상세 (`index.js`)
+## 자동화 스크립트 상세 (`nexacro_automation_library.js`)
 
 이 프로젝트의 핵심은 DOM 요소를 직접 제어하는 대신 Nexacro 프레임워크의 내부 API를 활용하는 것입니다.
 


### PR DESCRIPTION
## Summary
- sync README config example with current `config.json`
- mention listener script and other new options
- update references from `index.js` to `nexacro_automation_library.js`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889451711a0832098f40e79fdc9e9c9