### PR TITLE
Fix DB init when missing

### DIFF
--- a/tests/test_prediction.py
+++ b/tests/test_prediction.py
@@ -1,0 +1,24 @@
+import importlib.util
+import pathlib
+from unittest.mock import patch
+
+db_util_spec = importlib.util.spec_from_file_location(
+    "db_util", pathlib.Path(__file__).resolve().parents[1] / "utils" / "db_util.py"
+)
+db_util = importlib.util.module_from_spec(db_util_spec)
+db_util_spec.loader.exec_module(db_util)
+
+
+def test_run_jumeokbap_prediction_creates_db(tmp_path, monkeypatch):
+    sales_db = tmp_path / "sales.db"
+    jumeok_db = tmp_path / "jumeok.db"
+
+    monkeypatch.setattr(db_util, "get_configured_db_path", lambda: sales_db)
+    monkeypatch.setattr(db_util, "JUMEOKBAP_DB_PATH", jumeok_db, raising=False)
+    monkeypatch.setattr(db_util, "predict_jumeokbap_quantity", lambda p: 1.0)
+    monkeypatch.setattr(db_util, "recommend_product_mix", lambda p, q: {})
+
+    db_util.run_jumeokbap_prediction_and_save()
+
+    assert sales_db.exists()
+    assert jumeok_db.exists()

--- a/utils/db_util.py
+++ b/utils/db_util.py
@@ -312,10 +312,13 @@ def run_jumeokbap_prediction_and_save():
     """주먹밥 판매량 예측을 실행하고 결과를 DB에 저장합니다."""
     try:
         db_path = get_configured_db_path()
-        Path(DB_FILE).parent.mkdir(parents=True, exist_ok=True)
+        db_path.parent.mkdir(parents=True, exist_ok=True)
         if not db_path.exists():
-            log.error(f"데이터베이스 파일을 찾을 수 없습니다: {db_path}")
-            return
+            log.info(
+                f"데이터베이스가 없어 새로 생성합니다: {db_path}",
+                extra={"tag": "system"},
+            )
+            init_db(db_path)
 
         forecast = predict_jumeokbap_quantity(db_path)
         mix = recommend_product_mix(db_path, forecast)


### PR DESCRIPTION
## Summary
- ensure `run_jumeokbap_prediction_and_save` creates the integrated DB file when missing
- add regression test for prediction DB creation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688995ef8ccc832099941612fa2bdb43