### PR TITLE
fix: correct date variable in weather error log

### DIFF
--- a/prediction/model.py
+++ b/prediction/model.py
@@ -65,7 +65,10 @@ def get_weather_data(dates: list[datetime.date]) -> pd.DataFrame:
             log.error(f"{date} 날씨 데이터 요청 중 오류: {e}. 기본값으로 대체합니다.", exc_info=True)
             weather_data.append({'date': date, 'temperature': 15, 'rainfall': 0}) # Fallback values
         except Exception as e:
-            log.error(f"{dt} 날씨 데이터 파싱 중 예상치 못한 오류: {e}. 기본값으로 대체합니다.", exc_info=True)
+            log.error(
+                f"{date} 날씨 데이터 파싱 중 예상치 못한 오류: {e}. 기본값으로 대체합니다.",
+                exc_info=True,
+            )
             weather_data.append({'date': date, 'temperature': 15, 'rainfall': 0}) # Fallback values
 
     return pd.DataFrame(weather_data)


### PR DESCRIPTION
## Summary
- fix weather data error log to use correct `date` variable

## Testing
- `pytest -q` *(fails: KeyError, ValueError, AttributeError)*

------
https://chatgpt.com/codex/tasks/task_e_688efd7fac948320a7139716341817fc