### PR TITLE
Use parameter binding in prediction model

### DIFF
--- a/prediction/model.py
+++ b/prediction/model.py
@@ -79,8 +79,11 @@ def get_training_data_for_category(db_path: Path, mid_code: str) -> pd.DataFrame
         return pd.DataFrame()
 
     with sqlite3.connect(db_path) as conn:
-        query = f"SELECT collected_at, SUM(sales) as total_sales FROM mid_sales WHERE mid_code = '{mid_code}' GROUP BY SUBSTR(collected_at, 1, 10)"
-        df = pd.read_sql(query, conn)
+        query = (
+            "SELECT collected_at, SUM(sales) as total_sales "
+            "FROM mid_sales WHERE mid_code = ? GROUP BY SUBSTR(collected_at, 1, 10)"
+        )
+        df = pd.read_sql(query, conn, params=(mid_code,))
 
     if df.empty:
         return pd.DataFrame()


### PR DESCRIPTION
## Summary
- avoid SQL injection in training data retrieval by binding parameters instead of string formatting

## Testing
- `PYTHONDONTWRITEBYTECODE=1 pytest` *(fails: KeyError: 'db_file', ValueError: unconverted data remains: :35, AttributeError: get_configured_db_path)*

------
https://chatgpt.com/codex/tasks/task_e_688efeb32fa88320bfb3ff227802cac3