### PR TITLE
Normalize collected_at to date to prevent duplicate insert

### DIFF
--- a/utils/db_util.py
+++ b/utils/db_util.py
@@ -72,11 +72,9 @@ def write_sales_data(
 
         if target_date_str:
             current_date = f"{target_date_str[:4]}-{target_date_str[4:6]}-{target_date_str[6:]}"
-            collected_at_val = f"{current_date} 00:00:00"
         else:
-            now = datetime.now()
-            collected_at_val = now.strftime("%Y-%m-%d %H:%M:%S")
-            current_date = now.strftime("%Y-%m-%d")
+            current_date = datetime.now().strftime("%Y-%m-%d")
+        collected_at_val = f"{current_date} 00:00:00"
 
         current_date_dt = datetime.strptime(current_date, "%Y-%m-%d").date()
         weekday = current_date_dt.weekday()


### PR DESCRIPTION
## Summary
- fix `write_sales_data` to store `collected_at` at midnight for the target date
- prevents duplicate rows when the function runs multiple times on the same day

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6891562f3cc4832099810b43d2dad77d