### PR TITLE
Ensure JSON logging for complex objects

### DIFF
--- a/data_collector.py
+++ b/data_collector.py
@@ -6,6 +6,7 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any
 import logging
+import json
 
 try:
     from selenium.webdriver.support.ui import WebDriverWait
@@ -66,7 +67,10 @@ def execute_collect_single_day_data(driver: Any, date_str: str) -> dict:
         time.sleep(0.5)
 
     success = isinstance(parsed, list) and len(parsed) > 0
-    logger.info(f"[execute_collect_single_day_data] Raw data from JS: {parsed}")
+    logger.info(
+        "[execute_collect_single_day_data] Raw data from JS: %s",
+        json.dumps(parsed, ensure_ascii=False),
+    )
     return {"success": bool(success), "data": parsed if success else None}
 
 
@@ -105,7 +109,9 @@ def collect_and_save(driver: Any, db_path: Path, store_name: str) -> None:
     missing_past_dates = get_missing_past_dates(db_path)
     if missing_past_dates:
         log.info(
-            f"Missing past dates for {store_name}: {missing_past_dates}. Attempting to collect..."
+            "Missing past dates for %s: %s. Attempting to collect...",
+            store_name,
+            json.dumps(missing_past_dates, ensure_ascii=False),
         )
         for past in missing_past_dates:
             result = execute_collect_single_day_data(driver, past)
@@ -127,7 +133,11 @@ def collect_and_save(driver: Any, db_path: Path, store_name: str) -> None:
             log.info(
                 f"[{store_name}] Successfully collected {len(collected)} records for {today_str}."
             )
-            log.info(f"[{store_name}] Data to be written: {collected}")
+            log.info(
+                "[%s] Data to be written: %s",
+                store_name,
+                json.dumps(collected, ensure_ascii=False),
+            )
             log.info(f"[{store_name}] --- Calling write_sales_data ---")
             write_sales_data(collected, db_path, store_id=store_name)
             log.info(f"[{store_name}] --- Returned from write_sales_data ---")
@@ -135,7 +145,10 @@ def collect_and_save(driver: Any, db_path: Path, store_name: str) -> None:
                 handler.flush()
         else:
             log.warning(
-                f"No valid data collected for {today_str} at store {store_name}. Collected data: {collected}"
+                "No valid data collected for %s at store %s. Collected data: %s",
+                today_str,
+                store_name,
+                json.dumps(collected, ensure_ascii=False),
             )
     except Exception as e:
         log.error(

--- a/prediction/model.py
+++ b/prediction/model.py
@@ -62,7 +62,11 @@ def get_weather_data(dates: list[datetime.date]) -> pd.DataFrame:
             response = requests.get(url, timeout=10)
             response.raise_for_status()
             data = response.json()
-            log.debug(f"Weather API raw response for {date}: {json.dumps(data, indent=2)}")
+            log.debug(
+                "Weather API raw response for %s: %s",
+                date,
+                json.dumps(data, ensure_ascii=False),
+            )
 
             result_code = (
                 data.get('response', {}).get('header', {}).get('resultCode')
@@ -76,7 +80,11 @@ def get_weather_data(dates: list[datetime.date]) -> pd.DataFrame:
             total_rainfall = 0.0
 
             items = data.get('response', {}).get('body', {}).get('items', {}).get('item', [])
-            log.debug(f"Weather API parsed items for {date}: {items}")
+            log.debug(
+                "Weather API parsed items for %s: %s",
+                date,
+                json.dumps(items, ensure_ascii=False),
+            )
 
             for item in items:
                 category = item.get('category')
@@ -337,8 +345,14 @@ def recommend_product_mix(db_path: Path, mid_code: str, predicted_sales: float) 
 
     # 최종 추천 수량 합계 로깅
     total_recommended_quantity = sum(rec['recommended_quantity'] for rec in final_recommendations)
-    log.info(f"[{mid_code}] Predicted: {predicted_sales:.2f}. Recommended {len(final_recommendations)} types of items with total quantity of {total_recommended_quantity}.")
-    log.info(f"[{mid_code}] Recommendation details: {final_recommendations}")
+    log.info(
+        f"[{mid_code}] Predicted: {predicted_sales:.2f}. Recommended {len(final_recommendations)} types of items with total quantity of {total_recommended_quantity}."
+    )
+    log.info(
+        "[%s] Recommendation details: %s",
+        mid_code,
+        json.dumps(final_recommendations, ensure_ascii=False),
+    )
 
     return final_recommendations
 

--- a/utils/db_util.py
+++ b/utils/db_util.py
@@ -2,6 +2,7 @@ import sqlite3
 from datetime import datetime, timedelta
 from pathlib import Path
 import logging
+import json
 import pandas as pd
 import holidays
 
@@ -96,20 +97,34 @@ def write_sales_data(
         rainfall = weather_df['rainfall'].iloc[0] if not weather_df.empty else 0.0
 
         for i, rec in enumerate(records):
-            logger.debug(f"Processing record {i+1}/{len(records)}: {rec}")
+            logger.debug(
+                "Processing record %s/%s: %s",
+                i + 1,
+                len(records),
+                json.dumps(rec, ensure_ascii=False),
+            )
             try:
                 product_code = _get_value(rec, "productCode", "product_code")
                 sales_raw = _get_value(rec, "sales", "SALE_QTY")
                 
                 if product_code is None or sales_raw is None:
-                    logger.warning(f"Record {i+1} is missing product_code or sales. Skipping. Record: {rec}")
+                    logger.warning(
+                        "Record %s is missing product_code or sales. Skipping. Record: %s",
+                        i + 1,
+                        json.dumps(rec, ensure_ascii=False),
+                    )
                     skipped_count += 1
                     continue
                 
                 try:
                     sales = int(sales_raw)
                 except (ValueError, TypeError):
-                    logger.warning(f"Record {i+1} has invalid sales value '{sales_raw}'. Skipping. Record: {rec}")
+                    logger.warning(
+                        "Record %s has invalid sales value '%s'. Skipping. Record: %s",
+                        i + 1,
+                        sales_raw,
+                        json.dumps(rec, ensure_ascii=False),
+                    )
                     skipped_count += 1
                     continue
 
@@ -184,7 +199,13 @@ def write_sales_data(
                     )
                 processed_count += 1
             except Exception as e:
-                logger.error(f"Error processing record {i+1}: {rec}. Error: {e}", exc_info=True)
+                logger.error(
+                    "Error processing record %s: %s. Error: %s",
+                    i + 1,
+                    json.dumps(rec, ensure_ascii=False),
+                    e,
+                    exc_info=True,
+                )
                 skipped_count += 1
 
         conn.commit()


### PR DESCRIPTION
## Summary
- serialize complex log data with `json.dumps(..., ensure_ascii=False)` in data collection and prediction modules
- update database utility logging to avoid embedding raw dicts

## Testing
- `pytest`
- `jq -c . logs/automation.log`

------
https://chatgpt.com/codex/tasks/task_e_689155c5c9b883208322dd47394ec365