### PR TITLE
Reflect soldout data in training and migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ JavaScript 스크립트에서 수집한 각 상품 데이터는 다음과 같은
 | `purchase`     | 매입액           |
 | `disposal`     | 폐기액           |
 | `stock`        | 재고액           |
+| `soldout`      | 품절 수량        |
 
 `write_sales_data` 함수는 위 필드명 외에도 `snake_case` 형태(`mid_code` 등)나 기존 텍스트 파일 포맷(`order`, `discard`)을 허용합니다.
 
@@ -197,6 +198,7 @@ CREATE TABLE IF NOT EXISTS mid_sales (
     purchase INTEGER,        -- 매입액
     disposal INTEGER,        -- 폐기액
     stock INTEGER,           -- 재고액
+    soldout INTEGER,         -- 품절 수량
     weekday INTEGER,         -- 요일
     month INTEGER,           -- 월
     week_of_year INTEGER,    -- 주차
@@ -205,6 +207,14 @@ CREATE TABLE IF NOT EXISTS mid_sales (
     rainfall REAL,           -- 강수량
     UNIQUE(collected_at, product_code) -- 이 조합은 고유해야 함
 );
+```
+
+## DB 마이그레이션
+
+기존 데이터베이스에 `soldout` 컬럼이 없다면 아래 스크립트를 실행하여 컬럼을 추가하고 공휴일 정보를 최신 규칙으로 갱신하세요.
+
+```bash
+python update_db_script.py
 ```
 
 ## 자동화 스크립트 상세 (`nexacro_automation_library.js`)

--- a/prediction/xgboost.py
+++ b/prediction/xgboost.py
@@ -124,7 +124,7 @@ def get_training_data_for_category(db_path: Path, mid_code: str) -> pd.DataFrame
 
     with sqlite3.connect(db_path) as conn:
         query = (
-            "SELECT collected_at, SUM(sales) as total_sales "
+            "SELECT collected_at, SUM(sales) as total_sales, SUM(soldout) as total_soldout "
             "FROM mid_sales WHERE mid_code = ? GROUP BY SUBSTR(collected_at, 1, 10)"
         )
         df = pd.read_sql(query, conn, params=(mid_code,))
@@ -140,7 +140,7 @@ def get_training_data_for_category(db_path: Path, mid_code: str) -> pd.DataFrame
     df['is_holiday'] = df['date'].apply(lambda x: x in kr_holidays).astype(int)
     
     log.debug(f"[{mid_code}] get_training_data_for_category returned {len(df)} rows.")
-    return df[['date', 'total_sales', 'weekday', 'month', 'week_of_year', 'is_holiday']]
+    return df[['date', 'total_sales', 'total_soldout', 'weekday', 'month', 'week_of_year', 'is_holiday']]
 
 
 def load_or_default_model(mid_code: str, model_dir: Path):
@@ -168,6 +168,7 @@ def train_and_predict(
         'is_holiday',
         'temperature',
         'rainfall',
+        'total_soldout',
     ]
 
     model = None
@@ -214,6 +215,7 @@ def train_and_predict(
         'is_holiday': int(tomorrow in holidays.KR()),
         'temperature': tomorrow_weather['temperature'].iloc[0],
         'rainfall': tomorrow_weather['rainfall'].iloc[0],
+        'total_soldout': 0,
     }
     tomorrow_df = pd.DataFrame([tomorrow_features])
 

--- a/tests/test_prediction.py
+++ b/tests/test_prediction.py
@@ -46,9 +46,9 @@ def test_run_all_category_predictions_creates_db(tmp_path, monkeypatch):
             """
             INSERT INTO mid_sales (
                 collected_at, mid_code, mid_name, product_code, product_name, sales,
-                order_cnt, purchase, disposal, stock, weekday, month, week_of_year,
+                order_cnt, purchase, disposal, stock, soldout, weekday, month, week_of_year,
                 is_holiday, temperature, rainfall
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 "2024-01-01 00:00:00",
@@ -57,6 +57,7 @@ def test_run_all_category_predictions_creates_db(tmp_path, monkeypatch):
                 "P001",
                 "Prod1",
                 5,
+                0,
                 0,
                 0,
                 0,
@@ -78,6 +79,7 @@ def test_run_all_category_predictions_creates_db(tmp_path, monkeypatch):
             {
                 "date": [datetime(2024, 1, 1).date()],
                 "total_sales": [5],
+                "total_soldout": [0],
                 "weekday": [0],
                 "month": [1],
                 "week_of_year": [1],
@@ -125,9 +127,9 @@ def test_run_for_db_paths_with_tuning(tmp_path, monkeypatch):
             """
             INSERT INTO mid_sales (
                 collected_at, mid_code, mid_name, product_code, product_name, sales,
-                order_cnt, purchase, disposal, stock, weekday, month, week_of_year,
+                order_cnt, purchase, disposal, stock, soldout, weekday, month, week_of_year,
                 is_holiday, temperature, rainfall
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 "2024-01-01 00:00:00",
@@ -136,6 +138,7 @@ def test_run_for_db_paths_with_tuning(tmp_path, monkeypatch):
                 "P001",
                 "Prod1",
                 5,
+                0,
                 0,
                 0,
                 0,
@@ -152,9 +155,9 @@ def test_run_for_db_paths_with_tuning(tmp_path, monkeypatch):
             """
             INSERT INTO mid_sales (
                 collected_at, mid_code, mid_name, product_code, product_name, sales,
-                order_cnt, purchase, disposal, stock, weekday, month, week_of_year,
+                order_cnt, purchase, disposal, stock, soldout, weekday, month, week_of_year,
                 is_holiday, temperature, rainfall
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 "2024-01-01 00:00:00",
@@ -163,6 +166,7 @@ def test_run_for_db_paths_with_tuning(tmp_path, monkeypatch):
                 "P002",
                 "Prod2",
                 3,
+                0,
                 0,
                 0,
                 0,
@@ -182,6 +186,7 @@ def test_run_for_db_paths_with_tuning(tmp_path, monkeypatch):
             {
                 "date": [datetime(2024, 1, 1).date()],
                 "total_sales": [1],
+                "total_soldout": [0],
                 "weekday": [0],
                 "month": [1],
                 "week_of_year": [1],
@@ -238,6 +243,7 @@ def test_recommend_product_mix_filters_stockouts(tmp_path):
             0,
             0,
             0,
+            0,
             date.weekday(),
             date.month,
             date.isocalendar()[1],
@@ -259,9 +265,9 @@ def test_recommend_product_mix_filters_stockouts(tmp_path):
     insert_sql = """
         INSERT INTO mid_sales (
             collected_at, mid_code, mid_name, product_code, product_name, sales,
-            order_cnt, purchase, disposal, stock, weekday, month, week_of_year,
+            order_cnt, purchase, disposal, stock, soldout, weekday, month, week_of_year,
             is_holiday, temperature, rainfall
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     """
     with sqlite3.connect(db_path) as conn:
         conn.executemany(insert_sql, rows)

--- a/tests/test_xgboost_model.py
+++ b/tests/test_xgboost_model.py
@@ -1,6 +1,5 @@
-import pickle
-
 import pandas as pd
+import pickle
 
 from prediction import xgboost
 

--- a/update_db_script.py
+++ b/update_db_script.py
@@ -1,8 +1,31 @@
 from pathlib import Path
+import sqlite3
+
 from utils.db_util import update_past_holiday_data
+
 
 DB_PATH = Path("C:/Users/kanur/OneDrive/문서/GitHub/aaa/code_outputs/db/dongyang.db")
 
+
+def add_soldout_column(db_path: Path) -> None:
+    """기존 mid_sales 테이블에 soldout 컬럼을 추가합니다."""
+    if not db_path.exists():
+        print(f"DB 파일이 존재하지 않습니다: {db_path}")
+        return
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    cur.execute("PRAGMA table_info(mid_sales)")
+    columns = [row[1] for row in cur.fetchall()]
+    if "soldout" not in columns:
+        cur.execute("ALTER TABLE mid_sales ADD COLUMN soldout INTEGER DEFAULT 0")
+        conn.commit()
+        print("'soldout' 컬럼을 추가했습니다.")
+    else:
+        print("'soldout' 컬럼이 이미 존재합니다.")
+    conn.close()
+
+
 if __name__ == "__main__":
+    add_soldout_column(DB_PATH)
     update_past_holiday_data(DB_PATH)
     print("Database update script finished.")


### PR DESCRIPTION
## Summary
- Include daily soldout totals when preparing training data and model features
- Add DB migration helper to add `soldout` column and document migration steps
- Update tests and docs for new soldout field

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689178010ab0832080332da751938e7d