### PR TITLE
수요 예측에 폐기 반영 및 파생 피처 추가

### DIFF
--- a/tests/test_prediction.py
+++ b/tests/test_prediction.py
@@ -79,6 +79,8 @@ def test_run_all_category_predictions_creates_db(tmp_path, monkeypatch):
             {
                 "date": [datetime(2024, 1, 1).date()],
                 "total_sales": [5],
+                "total_purchase": [5],
+                "total_disposal": [0],
                 "total_soldout": [0],
                 "total_stock": [20],
                 "is_stockout": [0],
@@ -86,6 +88,10 @@ def test_run_all_category_predictions_creates_db(tmp_path, monkeypatch):
                 "month": [1],
                 "week_of_year": [1],
                 "is_holiday": [0],
+                "true_demand": [5],
+                "disposal_ratio": [0.0],
+                "demand_gap": [0],
+                "shelf_life_days": [0],
             }
         ),
     )
@@ -188,6 +194,8 @@ def test_run_for_db_paths_with_tuning(tmp_path, monkeypatch):
             {
                 "date": [datetime(2024, 1, 1).date()],
                 "total_sales": [1],
+                "total_purchase": [1],
+                "total_disposal": [0],
                 "total_soldout": [0],
                 "total_stock": [10],
                 "is_stockout": [0],
@@ -195,6 +203,10 @@ def test_run_for_db_paths_with_tuning(tmp_path, monkeypatch):
                 "month": [1],
                 "week_of_year": [1],
                 "is_holiday": [0],
+                "true_demand": [1],
+                "disposal_ratio": [0.0],
+                "demand_gap": [0],
+                "shelf_life_days": [0],
             }
         )
 


### PR DESCRIPTION
## Summary
- 재고 흐름을 반영하도록 중분류 학습 데이터에 입고·폐기량을 합산하고 파생 피처를 계산합니다.
- XGBoost 학습 시 실제 수요(true_demand)를 타깃으로 사용하고 폐기율, 수요 차이 등 신규 피처를 포함합니다.
- 테스트 데이터를 신규 스키마에 맞게 갱신합니다.

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891939333c88320ad921cdaa40be936