### PR TITLE
feat: update DB script to process all databases

### DIFF
--- a/update_db_script.py
+++ b/update_db_script.py
@@ -1,31 +1,39 @@
 from pathlib import Path
 import sqlite3
+import logging
 
 from utils.db_util import update_past_holiday_data
 
 
-DB_PATH = Path("C:/Users/kanur/OneDrive/문서/GitHub/aaa/code_outputs/db/dongyang.db")
+DB_DIR = Path(__file__).resolve().parent / "code_outputs/db"
+log = logging.getLogger(__name__)
 
 
-def add_soldout_column(db_path: Path) -> None:
-    """기존 mid_sales 테이블에 soldout 컬럼을 추가합니다."""
-    if not db_path.exists():
-        print(f"DB 파일이 존재하지 않습니다: {db_path}")
-        return
-    conn = sqlite3.connect(db_path)
-    cur = conn.cursor()
-    cur.execute("PRAGMA table_info(mid_sales)")
-    columns = [row[1] for row in cur.fetchall()]
-    if "soldout" not in columns:
-        cur.execute("ALTER TABLE mid_sales ADD COLUMN soldout INTEGER DEFAULT 0")
-        conn.commit()
-        print("'soldout' 컬럼을 추가했습니다.")
-    else:
-        print("'soldout' 컬럼이 이미 존재합니다.")
-    conn.close()
+def main() -> None:
+    for db_path in DB_DIR.glob("*.db"):
+        try:
+            with sqlite3.connect(db_path) as conn:
+                cur = conn.cursor()
+                cur.execute("PRAGMA table_info(mid_sales)")
+                columns = [row[1] for row in cur.fetchall()]
+                if "soldout" not in columns:
+                    cur.execute(
+                        "ALTER TABLE mid_sales ADD COLUMN soldout INTEGER DEFAULT 0"
+                    )
+                    conn.commit()
+                    print(f"[SUCCESS] {db_path.name}")
+                else:
+                    print(f"[SKIP] {db_path.name}")
+
+            update_past_holiday_data(db_path)
+        except Exception:
+            log.exception(f"Error processing {db_path}")
+            print(f"[ERROR] {db_path.name}")
+            continue
+
+    print("All database update tasks completed.")
 
 
 if __name__ == "__main__":
-    add_soldout_column(DB_PATH)
-    update_past_holiday_data(DB_PATH)
-    print("Database update script finished.")
+    main()
+


### PR DESCRIPTION
## Summary
- iterate through all DB files in `code_outputs/db` directory and ensure `soldout` column exists
- run `update_past_holiday_data` for each database

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6891a84f35f08320a734e8380052ac1f